### PR TITLE
Fix naming of types for fields nested under unions

### DIFF
--- a/packages/graphql-typescript-definitions/src/print/document/index.ts
+++ b/packages/graphql-typescript-definitions/src/print/document/index.ts
@@ -36,7 +36,7 @@ export function printDocument(
       const body = tsInterfaceBodyForObjectField(
         fragment,
         fragment.typeCondition,
-        new ObjectStack(fragment.typeCondition, []),
+        new ObjectStack(fragment.typeCondition),
         context,
       );
 
@@ -96,7 +96,7 @@ export function printDocument(
     tsInterfaceBodyForObjectField(
       operation,
       rootType,
-      new ObjectStack(rootType, []),
+      new ObjectStack(rootType),
       context,
     ),
   );
@@ -108,7 +108,7 @@ export function printDocument(
     tsInterfaceBodyForObjectField(
       operation,
       rootType,
-      new ObjectStack(rootType, []),
+      new ObjectStack(rootType),
       partialContext,
     ),
   );

--- a/packages/graphql-typescript-definitions/src/print/document/language.ts
+++ b/packages/graphql-typescript-definitions/src/print/document/language.ts
@@ -88,7 +88,7 @@ function tsTypeForInlineFragment(
 ) {
   const {typeCondition} = inlineFragment;
   const interfaceDeclaration = t.tsInterfaceDeclaration(
-    t.identifier(`${stack.name}${typeCondition.name}`),
+    t.identifier(stack.name),
     null,
     null,
     tsInterfaceBodyForObjectField(
@@ -140,14 +140,15 @@ function tsTypeForObjectField(
     let otherType: t.TSType | null = null;
 
     if (missingPossibleTypes.length > 0) {
+      const otherStack = stack.fragment();
       const otherTypeInterface = t.tsInterfaceDeclaration(
-        t.identifier(`${stack.name}Other`),
+        t.identifier(otherStack.name),
         null,
         null,
         tsInterfaceBodyForObjectField(
           field,
           missingPossibleTypes,
-          stack,
+          otherStack,
           context,
           context.options.partial,
         ),

--- a/packages/graphql-typescript-definitions/src/print/document/utilities.ts
+++ b/packages/graphql-typescript-definitions/src/print/document/utilities.ts
@@ -1,5 +1,16 @@
 import {ucFirst} from 'change-case';
-import {GraphQLCompositeType} from 'graphql';
+import {
+  GraphQLCompositeType,
+  // We need to bring these in as they are implicitly referenced by
+  // GraphQLCompositeType, but TypeScript doesn’t know this when it
+  // generates its declaration files.
+  // @ts-ignore
+  GraphQLInterfaceType,
+  // @ts-ignore
+  GraphQLObjectType,
+  // @ts-ignore
+  GraphQLUnionType,
+} from 'graphql';
 import {Field} from 'graphql-tool-utilities/ast';
 
 export class ObjectStack {

--- a/packages/graphql-typescript-definitions/src/print/document/utilities.ts
+++ b/packages/graphql-typescript-definitions/src/print/document/utilities.ts
@@ -7,13 +7,14 @@ export class ObjectStack {
 
   get name(): string {
     const {parent, field, isFragment, type} = this;
-    const name = `${parent ? parent.name : ''}${ucFirst(field.responseName)}`;
+    const fieldName = field ? ucFirst(field.responseName) : '';
+    const name = `${parent ? parent.name : ''}${fieldName}`;
     return isFragment ? `${name}${type ? type.name : 'Other'}` : name;
   }
 
   constructor(
-    private type: GraphQLCompositeType | undefined,
-    private field: Field,
+    private type?: GraphQLCompositeType,
+    private field?: Field,
     private parent?: ObjectStack,
     private isFragment = false,
   ) {}

--- a/packages/graphql-typescript-definitions/src/print/document/utilities.ts
+++ b/packages/graphql-typescript-definitions/src/print/document/utilities.ts
@@ -5,23 +5,25 @@ import {Field} from 'graphql-tool-utilities/ast';
 export class ObjectStack {
   private seenFields = new Set<string>();
 
-  get name() {
-    return this.parentFields
-      .map(({responseName}) => ucFirst(responseName))
-      .join('');
+  get name(): string {
+    const {parent, field, isFragment, type} = this;
+    const name = `${parent ? parent.name : ''}${ucFirst(field.responseName)}`;
+    return isFragment ? `${name}${type ? type.name : 'Other'}` : name;
   }
 
   constructor(
-    _type: GraphQLCompositeType,
-    private parentFields: Field[] = [],
+    private type: GraphQLCompositeType | undefined,
+    private field: Field,
+    private parent?: ObjectStack,
+    private isFragment = false,
   ) {}
 
   nested(field: Field, type: GraphQLCompositeType) {
-    return new ObjectStack(type, [...this.parentFields, field]);
+    return new ObjectStack(type, field, this);
   }
 
-  fragment(type: GraphQLCompositeType) {
-    return new ObjectStack(type, this.parentFields);
+  fragment(type?: GraphQLCompositeType) {
+    return new ObjectStack(type, this.field, this.parent, true);
   }
 
   sawField(field: Field) {

--- a/packages/graphql-typescript-definitions/test/document.test.ts
+++ b/packages/graphql-typescript-definitions/test/document.test.ts
@@ -939,18 +939,18 @@ describe('printDocument()', () => {
     describe('unions', () => {
       function createBasicUnionSchema() {
         return buildSchema(`
-          type Person implements Named {
+          type Person {
             name: String!
             occupation: String
             pets: [Pet!]!
           }
 
-          type Dog implements Named {
+          type Dog {
             name: String!
             legs: Int!
           }
 
-          type Cat implements Named {
+          type Cat {
             name: String!
             livesLeft: Int!
           }
@@ -1184,7 +1184,7 @@ describe('printDocument()', () => {
         `);
       });
 
-      it('resolves union types nested within other union types', () => {
+      it('resolves union types nested within other union types with namespaced types', () => {
         const schema = createBasicUnionSchema();
 
         expect(
@@ -1203,16 +1203,16 @@ describe('printDocument()', () => {
           ),
         ).toContain(stripIndent`
           export namespace DetailsQueryData {
-            export interface NamedPetsDog {
+            export interface NamedPersonPetsDog {
               __typename: "Dog";
               legs: number;
             }
-            export interface NamedPetsOther {
+            export interface NamedPersonPetsOther {
               __typename: "Cat";
             }
             export interface NamedPerson {
               __typename: "Person";
-              pets: (DetailsQueryData.NamedPetsDog | DetailsQueryData.NamedPetsOther)[];
+              pets: (DetailsQueryData.NamedPersonPetsDog | DetailsQueryData.NamedPersonPetsOther)[];
             }
             export interface NamedOther {
               __typename: "Dog" | "Cat";


### PR DESCRIPTION
Our type generation had a weird edge case that breaks: when you have a union type, and multiple members of that union each have a field whose name matches between them, we generate a non-unique interface name. This PR namespaces all fields under unions in order to avoid such conflicts (see the added test for details).

cc/ @tsov since this was uncovered by online store [here](https://github.com/Shopify/online-store-web/pull/586/files).