### PR TITLE
Support `any` type for custom scalars

### DIFF
--- a/packages/graphql-typescript-definitions/src/cli.ts
+++ b/packages/graphql-typescript-definitions/src/cli.ts
@@ -33,6 +33,12 @@ const argv = yargs
     type: 'boolean',
     describe: 'Add a __typename field to every object type',
   })
+  .option('scalar-any', {
+    required: false,
+    default: false,
+    type: 'boolean',
+    describe: 'Generate custom scalars as `any` type',
+  })
   .option('enum-format', {
     required: false,
     type: 'string',

--- a/packages/graphql-typescript-definitions/src/index.ts
+++ b/packages/graphql-typescript-definitions/src/index.ts
@@ -24,6 +24,7 @@ export interface Options {
   schemaTypesPath: string;
   addTypename: boolean;
   enumFormat?: EnumFormat;
+  scalarAny?: boolean;
 }
 
 export interface RunOptions {

--- a/packages/graphql-typescript-definitions/src/print/schema/index.ts
+++ b/packages/graphql-typescript-definitions/src/print/schema/index.ts
@@ -21,6 +21,7 @@ type InputType = GraphQLEnumType | GraphQLScalarType | GraphQLInputObjectType;
 
 export interface Options {
   enumFormat?: EnumFormat;
+  scalarAny?: boolean;
 }
 
 export function printSchema(schema: GraphQLSchema, options: Options = {}) {
@@ -48,7 +49,7 @@ function tsTypeForRootInputType(type: InputType, options: Options) {
   if (isEnumType(type)) {
     return tsEnumForType(type, options);
   } else if (isScalarType(type)) {
-    return tsScalarForType(type);
+    return tsScalarForType(type, options);
   } else {
     return tsInputObjectForType(type);
   }
@@ -97,11 +98,11 @@ function tsInputObjectForType(type: GraphQLInputObjectType) {
   );
 }
 
-function tsScalarForType(type: GraphQLScalarType) {
+function tsScalarForType(type: GraphQLScalarType, {scalarAny}: Options) {
   return t.tsTypeAliasDeclaration(
     t.identifier(type.name),
     null,
-    t.tsStringKeyword(),
+    scalarAny ? t.tsAnyKeyword() : t.tsStringKeyword(),
   );
 }
 

--- a/packages/graphql-typescript-definitions/test/__snapshots__/cli.test.ts.snap
+++ b/packages/graphql-typescript-definitions/test/__snapshots__/cli.test.ts.snap
@@ -46,6 +46,7 @@ ENOENT: no such file or directory, open 'packages/graphql-typescript-definitions
     at Builder.<anonymous> (packages/graphql-typescript-definitions/lib/index.js)
     at Generator.throw (<anonymous>)
     at rejected (packages/graphql-typescript-definitions/lib/index.js)
+    at <anonymous>
 
 ",
 }

--- a/packages/graphql-typescript-definitions/test/__snapshots__/cli.test.ts.snap
+++ b/packages/graphql-typescript-definitions/test/__snapshots__/cli.test.ts.snap
@@ -46,7 +46,6 @@ ENOENT: no such file or directory, open 'packages/graphql-typescript-definitions
     at Builder.<anonymous> (packages/graphql-typescript-definitions/lib/index.js)
     at Generator.throw (<anonymous>)
     at rejected (packages/graphql-typescript-definitions/lib/index.js)
-    at <anonymous>
 
 ",
 }

--- a/packages/graphql-typescript-definitions/test/schema.test.ts
+++ b/packages/graphql-typescript-definitions/test/schema.test.ts
@@ -147,4 +147,26 @@ describe('printSchema()', () => {
       }
     `);
   });
+
+  describe('custom scalar', () => {
+    const schema = buildSchema(`
+      scalar JSON
+    `);
+
+    describe('with scalarAny', () => {
+      it('prints the scalar type as `any`', () => {
+        expect(printSchema(schema, {scalarAny: true})).toContain(stripIndent`
+        export type JSON = any;
+      `);
+      });
+    });
+
+    describe('without scalarAny', () => {
+      it('prints the scalar type as `string`', () => {
+        expect(printSchema(schema)).toContain(stripIndent`
+        export type JSON = string;
+      `);
+      });
+    });
+  });
 });


### PR DESCRIPTION
Hi there!

Thanks for writing a great library! This has been immensely useful for us.

In our GraphQL backend, we have a custom scalar used for representing JSON. Currently, this always get represented as a `string` type when the Typescript types are generated. For our custom scalar case, we want this to be an `any` type, so that it can be used like object in our Typescript code.

This PR adds a CLI option to specify the type for custom scalars as any - I didn't see a way for this to be configured on a per scalar basis, but open to any feedback if there's a better way to implement this!