### PR TITLE
Error on duplicate query names

### DIFF
--- a/packages/graphql-typescript-definitions/src/index.ts
+++ b/packages/graphql-typescript-definitions/src/index.ts
@@ -9,6 +9,7 @@ import {
   Source,
   concatAST,
 } from 'graphql';
+import chalk from 'chalk';
 import {dirname} from 'path';
 import {readJSON, readFile, writeFile, mkdirp} from 'fs-extra';
 import {watch} from 'chokidar';
@@ -165,9 +166,9 @@ export class Builder extends EventEmitter {
     if (duplicateOperations.length) {
       duplicateOperations.forEach(({name, files}) => {
         const error = new Error(
-          `Graphql operations must have a unique name. The operation "${name}" is declared in:\n ${files.join(
-            '\n ',
-          )}`,
+          `GraphQL operations must have a unique name. The operation ${chalk.bold(
+            name,
+          )} is declared in:\n ${files.join('\n ')}`,
         );
         this.emit('error', error);
       });

--- a/packages/graphql-typescript-definitions/test/__snapshots__/cli.test.ts.snap
+++ b/packages/graphql-typescript-definitions/test/__snapshots__/cli.test.ts.snap
@@ -12,9 +12,13 @@ Object {
   "stdout": "
  BUILT  packages/graphql-typescript-definitions/test/fixtures/duplicate-names/schema.ts
 
- ERROR  Graphql operations must have unique names. Found 2 or more operations with the name \\"FindPerson\\"
-Error: Graphql operations must have unique names. Found 2 or more operations with the name \\"FindPerson\\"
-    at duplicateNames.forEach (packages/graphql-typescript-definitions/lib/index.js)
+ ERROR  Graphql operations must have a unique name. The operation \\"FindPerson\\" is declared in:
+ packages/graphql-typescript-definitions/test/fixtures/duplicate-names/documents/Query2/FindPersonQuery.graphql
+ packages/graphql-typescript-definitions/test/fixtures/duplicate-names/documents/Query1/FindPersonsQuery.graphql
+Error: Graphql operations must have a unique name. The operation \\"FindPerson\\" is declared in:
+ packages/graphql-typescript-definitions/test/fixtures/duplicate-names/documents/Query2/FindPersonQuery.graphql
+ packages/graphql-typescript-definitions/test/fixtures/duplicate-names/documents/Query1/FindPersonsQuery.graphql
+    at duplicateOperations.forEach (packages/graphql-typescript-definitions/lib/index.js)
     at Array.forEach (<anonymous>)
     at Builder.<anonymous> (packages/graphql-typescript-definitions/lib/index.js)
     at Generator.next (<anonymous>)

--- a/packages/graphql-typescript-definitions/test/__snapshots__/cli.test.ts.snap
+++ b/packages/graphql-typescript-definitions/test/__snapshots__/cli.test.ts.snap
@@ -1,5 +1,34 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`cli fails when multiple queries have the same name 1`] = `
+Object {
+  "error": Object {
+    "cmd": "packages/graphql-typescript-definitions/bin/graphql-typescript-definitions 'packages/graphql-typescript-definitions/test/fixtures/duplicate-names/documents/**/*.graphql' --schema-path 'packages/graphql-typescript-definitions/test/fixtures/duplicate-names/schema.json' --schema-types-path 'packages/graphql-typescript-definitions/test/fixtures/duplicate-names/schema.ts'",
+    "code": 1,
+    "killed": false,
+    "signal": null,
+  },
+  "stderr": "",
+  "stdout": "
+ BUILT  packages/graphql-typescript-definitions/test/fixtures/duplicate-names/schema.ts
+
+ ERROR  Graphql operations must have unique names. Found 2 or more operations with the name \\"FindPerson\\"
+Error: Graphql operations must have unique names. Found 2 or more operations with the name \\"FindPerson\\"
+    at duplicateNames.forEach (packages/graphql-typescript-definitions/lib/index.js)
+    at Array.forEach (<anonymous>)
+    at Builder.<anonymous> (packages/graphql-typescript-definitions/lib/index.js)
+    at Generator.next (<anonymous>)
+    at packages/graphql-typescript-definitions/lib/index.js
+    at new Promise (<anonymous>)
+    at __awaiter (packages/graphql-typescript-definitions/lib/index.js)
+    at Builder.generateDocumentTypes (packages/graphql-typescript-definitions/lib/index.js)
+    at Builder.<anonymous> (packages/graphql-typescript-definitions/lib/index.js)
+    at Generator.next (<anonymous>)
+
+",
+}
+`;
+
 exports[`cli fails when there are syntax errors 1`] = `
 Object {
   "error": Object {

--- a/packages/graphql-typescript-definitions/test/__snapshots__/cli.test.ts.snap
+++ b/packages/graphql-typescript-definitions/test/__snapshots__/cli.test.ts.snap
@@ -12,12 +12,12 @@ Object {
   "stdout": "
  BUILT  packages/graphql-typescript-definitions/test/fixtures/duplicate-names/schema.ts
 
- ERROR  Graphql operations must have a unique name. The operation \\"FindPerson\\" is declared in:
- packages/graphql-typescript-definitions/test/fixtures/duplicate-names/documents/Query2/FindPersonQuery.graphql
+ ERROR  GraphQL operations must have a unique name. The operation FindPerson is declared in:
  packages/graphql-typescript-definitions/test/fixtures/duplicate-names/documents/Query1/FindPersonsQuery.graphql
-Error: Graphql operations must have a unique name. The operation \\"FindPerson\\" is declared in:
  packages/graphql-typescript-definitions/test/fixtures/duplicate-names/documents/Query2/FindPersonQuery.graphql
+Error: GraphQL operations must have a unique name. The operation FindPerson is declared in:
  packages/graphql-typescript-definitions/test/fixtures/duplicate-names/documents/Query1/FindPersonsQuery.graphql
+ packages/graphql-typescript-definitions/test/fixtures/duplicate-names/documents/Query2/FindPersonQuery.graphql
     at duplicateOperations.forEach (packages/graphql-typescript-definitions/lib/index.js)
     at Array.forEach (<anonymous>)
     at Builder.<anonymous> (packages/graphql-typescript-definitions/lib/index.js)

--- a/packages/graphql-typescript-definitions/test/cli.test.ts
+++ b/packages/graphql-typescript-definitions/test/cli.test.ts
@@ -27,6 +27,12 @@ describe('cli', () => {
       await execDetails(cliCommandForFixtureDirectory('missing-types')),
     ).toMatchSnapshot();
   });
+
+  it('fails when multiple queries have the same name', async () => {
+    expect(
+      await execDetails(cliCommandForFixtureDirectory('duplicate-names')),
+    ).toMatchSnapshot();
+  });
 });
 
 function execDetails(command: string) {

--- a/packages/graphql-typescript-definitions/test/fixtures/duplicate-names/documents/Query1/FindPeopleQuery.graphql
+++ b/packages/graphql-typescript-definitions/test/fixtures/duplicate-names/documents/Query1/FindPeopleQuery.graphql
@@ -1,0 +1,5 @@
+query FindPeople {
+  people {
+    id
+  }
+}

--- a/packages/graphql-typescript-definitions/test/fixtures/duplicate-names/documents/Query1/FindPersonsQuery.graphql
+++ b/packages/graphql-typescript-definitions/test/fixtures/duplicate-names/documents/Query1/FindPersonsQuery.graphql
@@ -1,0 +1,5 @@
+query FindPerson {
+  person {
+    id
+  }
+}

--- a/packages/graphql-typescript-definitions/test/fixtures/duplicate-names/documents/Query2/FindPersonQuery.graphql
+++ b/packages/graphql-typescript-definitions/test/fixtures/duplicate-names/documents/Query2/FindPersonQuery.graphql
@@ -1,0 +1,5 @@
+query FindPerson {
+  person {
+    id
+  }
+}

--- a/packages/graphql-typescript-definitions/test/fixtures/duplicate-names/schema.graphql
+++ b/packages/graphql-typescript-definitions/test/fixtures/duplicate-names/schema.graphql
@@ -1,0 +1,20 @@
+enum Generation {
+  MILLENIAL
+  GEN_X
+}
+
+type Person {
+  id: ID!
+  name: String!
+  generation: Generation!
+  relatives: [Person!]!
+}
+
+type Query {
+  person: Person
+  people: [Person]
+}
+
+schema {
+  query: Query
+}


### PR DESCRIPTION
Branches from https://github.com/Shopify/graphql-tools-web/pull/13#issuecomment-415279569
Part of Shopify/sewing-kit#811

Adds an error for when multiple queries share the same name. 

**Question:** Should we crash or just log the error?

```shell
ERROR  Graphql operations must have unique names. Found 2 or more operations with the name "FindPerson"
```

----

### 🎩  Instructions for `web`

(may vary depeding on where you store project locally)

1. run `yarn build` from the root of this repo.
2. copy the built source to web `cp -R packages/graphql-typescript-definitions/lib/* ~/src/github.com/Shopify/web/node_modules/\@shopify/sewing-kit/node_modules/graphql-typescript-definitions/lib/
`
----
Screenshot for reference

<img width="764" alt="screen shot 2018-08-24 at 1 00 24 pm" src="https://user-images.githubusercontent.com/462077/44597477-bf8a0e00-a79d-11e8-9256-572da9c9bcf3.png">
