### PR TITLE
Remove director

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -1,4 +1,3 @@
-director: Chris Sauve
 owners:
   - lemonmade
 classification: library


### PR DESCRIPTION
**Owners**: @lemonmade
**Service**: [graphql-tools-web/production](https://services.shopify.io/services/graphql-tools-web/production)

Director ownership has been deprecated in favour of Product/Service Line ownership.

For more information on service ownership, you can read the docs in [Services DB](https://services.shopify.io/doc/ownership).
