### PR TITLE
adding support for multiple schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,86 @@ A loosely related set of packages for web projects using GraphQL and TypeScript.
 
 [![CircleCI](https://circleci.com/gh/Shopify/graphql-tools-web.svg?style=svg&circle-token=8dafbec2d33dcb489dfce1e82ed37c271b26aeba)](https://circleci.com/gh/Shopify/graphql-tools-web)
 
-## Packages
+## Configuration
+
+This tool consumes a [(Prisma) `.graphqlconfig`](https://github.com/prisma/graphql-config) file, typically placed in the root of the project. This configuration file is compatible with the [VSCode extension](https://github.com/prisma/vscode-graphql) to provide syntax highlighting and autocomplete suggestions. The configuration file supports a single nameless project or multiple named projects, each project is linked to a schema and a set of include and exclude globbing patterns. Upon processing a schema file, the schema's types will be extracted to `types.ts` or `${projectName}-types.ts` and written to the `schema-types-path` (or use the `schemaTypesPath` extension as an override). The `schemaPath` can be supplied in the configuration as a `.json` or a `.graphql` file, include and exclude globbing patterns should be supplied as _relative_ paths, relative to the location of the `.graphqlconfig`.
+
+See the [official specification documentation](https://github.com/prisma/graphql-config/blob/master/specification.md#use-cases) for more detail and examples.
+
+#### Examples
+
+A single nameless project configuration
+
+```json
+{
+  "schemaPath": "build/schema.json",
+  "includes": "app/**/*.graphql"
+}
+```
+
+A multi-project configuration
+
+```json
+{
+  "projects": {
+    "foo": {
+      "schemaPath": "build/schema/foo.json",
+      "includes": "app/foo/**/*.graphql"
+    },
+    "bar": {
+      "schemaPath": "build/schema/bar.json",
+      "includes": "app/bar/**/*.graphql"
+    }
+  }
+}
+```
+
+A project configuration with a `schemaTypesPath` override
+
+```json
+{
+  "projects": {
+    "foo": {
+      "schemaPath": "build/schema/foo.json",
+      "includes": "app/foo/**/*.graphql"
+    },
+    "bar": {
+      "schemaPath": "build/schema/bar.json",
+      "includes": "app/bar/**/*.graphql",
+      "extensions": {
+        "schemaTypesPath": "app/bar/types/graphql.ts"
+      }
+    }
+  }
+}
+```
+
+## CLI
+
+The command line interface can be run to manually process a configuration file.
+
+#### Options
+
+* `--schema-types-path`: specifies where to write schema types (**REQUIRED**)
+* `--watch`: watches the include globbing patterns for changes and re-processes files (default = `false`)
+* `--cwd`: run tool for `.graphqlconfig` located in this directory (default = `process.cwd()`)
+* `--add-typename`: adds a `__typename` field to every object type (default = `true`)
+* `--enum-format`: specifies output format for enum types (default = `undefined`)
+  * Options: `camel-case`, `pascal-case`, `snake-case`, `screaming-snake-case`
+  * `undefined` results in using the unchanged name from the schema (verbatim)
+
+#### Examples
+
+```sh
+# run tool for .graphqlconfig in current directory, produces ./types/types.ts
+graphql-typescript-definitions --schema-types-path types
+
+# run watcher for .graphqlconfig in current directory, produces ./types/types.ts
+graphql-typescript-definitions --schema-types-path types --watch
+
+# run tool for .graphqlconfig in a child directory, produces ./src/types/types.ts
+graphql-typescript-definitions --cwd src --schema-types-path types
+```
 
 ## Contribute
 

--- a/packages/graphql-typescript-definitions/package.json
+++ b/packages/graphql-typescript-definitions/package.json
@@ -43,6 +43,7 @@
     "fs-extra": "^6.0.0",
     "glob": "^7.1.2",
     "graphql": "^0.13.2",
+    "graphql-config": "^2.0.0",
     "graphql-tool-utilities": "^0.7.4"
   },
   "peerDependencies": {

--- a/packages/graphql-typescript-definitions/test/__snapshots__/cli.test.ts.snap
+++ b/packages/graphql-typescript-definitions/test/__snapshots__/cli.test.ts.snap
@@ -3,14 +3,14 @@
 exports[`cli fails when multiple queries have the same name 1`] = `
 Object {
   "error": Object {
-    "cmd": "packages/graphql-typescript-definitions/bin/graphql-typescript-definitions 'packages/graphql-typescript-definitions/test/fixtures/duplicate-names/documents/**/*.graphql' --schema-path 'packages/graphql-typescript-definitions/test/fixtures/duplicate-names/schema.json' --schema-types-path 'packages/graphql-typescript-definitions/test/fixtures/duplicate-names/schema.ts'",
+    "cmd": "packages/graphql-typescript-definitions/bin/graphql-typescript-definitions --cwd 'packages/graphql-typescript-definitions/test/fixtures/duplicate-names' --schema-types-path 'packages/graphql-typescript-definitions/test/fixtures/duplicate-names'",
     "code": 1,
     "killed": false,
     "signal": null,
   },
   "stderr": "",
   "stdout": "
- BUILT  packages/graphql-typescript-definitions/test/fixtures/duplicate-names/schema.ts
+ BUILT  packages/graphql-typescript-definitions/test/fixtures/duplicate-names/schema.json → packages/graphql-typescript-definitions/test/fixtures/duplicate-names/schema.ts
 
  ERROR  GraphQL operations must have a unique name. The operation FindPerson is declared in:
  packages/graphql-typescript-definitions/test/fixtures/duplicate-names/documents/Query1/FindPersonsQuery.graphql
@@ -18,7 +18,9 @@ Object {
 Error: GraphQL operations must have a unique name. The operation FindPerson is declared in:
  packages/graphql-typescript-definitions/test/fixtures/duplicate-names/documents/Query1/FindPersonsQuery.graphql
  packages/graphql-typescript-definitions/test/fixtures/duplicate-names/documents/Query2/FindPersonQuery.graphql
-    at duplicateOperations.forEach (packages/graphql-typescript-definitions/lib/index.js)
+    at duplicates.forEach (packages/graphql-typescript-definitions/lib/index.js)
+    at Array.forEach (<anonymous>)
+    at getDuplicateOperations.forEach (packages/graphql-typescript-definitions/lib/index.js)
     at Array.forEach (<anonymous>)
     at Builder.<anonymous> (packages/graphql-typescript-definitions/lib/index.js)
     at Generator.next (<anonymous>)
@@ -26,8 +28,6 @@ Error: GraphQL operations must have a unique name. The operation FindPerson is d
     at new Promise (<anonymous>)
     at __awaiter (packages/graphql-typescript-definitions/lib/index.js)
     at Builder.generateDocumentTypes (packages/graphql-typescript-definitions/lib/index.js)
-    at Builder.<anonymous> (packages/graphql-typescript-definitions/lib/index.js)
-    at Generator.next (<anonymous>)
 
 ",
 }
@@ -36,14 +36,14 @@ Error: GraphQL operations must have a unique name. The operation FindPerson is d
 exports[`cli fails when there are syntax errors 1`] = `
 Object {
   "error": Object {
-    "cmd": "packages/graphql-typescript-definitions/bin/graphql-typescript-definitions 'packages/graphql-typescript-definitions/test/fixtures/malformed-query/documents/**/*.graphql' --schema-path 'packages/graphql-typescript-definitions/test/fixtures/malformed-query/schema.json' --schema-types-path 'packages/graphql-typescript-definitions/test/fixtures/malformed-query/schema.ts'",
+    "cmd": "packages/graphql-typescript-definitions/bin/graphql-typescript-definitions --cwd 'packages/graphql-typescript-definitions/test/fixtures/malformed-query' --schema-types-path 'packages/graphql-typescript-definitions/test/fixtures/malformed-query'",
     "code": 1,
     "killed": false,
     "signal": null,
   },
   "stderr": "",
   "stdout": "
- BUILT  packages/graphql-typescript-definitions/test/fixtures/malformed-query/schema.ts
+ BUILT  packages/graphql-typescript-definitions/test/fixtures/malformed-query/schema.json → packages/graphql-typescript-definitions/test/fixtures/malformed-query/schema.ts
  ERROR  Syntax Error: Expected {, found Name \\"name\\"
 GraphQLError: Syntax Error: Expected {, found Name \\"name\\"
     at syntaxError (node_modules/graphql/error/syntaxError.js)
@@ -64,13 +64,14 @@ GraphQLError: Syntax Error: Expected {, found Name \\"name\\"
 exports[`cli fails when there are syntax errors 2`] = `
 Object {
   "error": Object {
-    "cmd": "packages/graphql-typescript-definitions/bin/graphql-typescript-definitions 'packages/graphql-typescript-definitions/test/fixtures/missing-schema/documents/**/*.graphql' --schema-path 'packages/graphql-typescript-definitions/test/fixtures/missing-schema/schema.json' --schema-types-path 'packages/graphql-typescript-definitions/test/fixtures/missing-schema/schema.ts'",
+    "cmd": "packages/graphql-typescript-definitions/bin/graphql-typescript-definitions --cwd 'packages/graphql-typescript-definitions/test/fixtures/missing-schema' --schema-types-path 'packages/graphql-typescript-definitions/test/fixtures/missing-schema'",
     "code": 1,
     "killed": false,
     "signal": null,
   },
   "stderr": "",
-  "stdout": " ERROR  Error parsing 'packages/graphql-typescript-definitions/test/fixtures/missing-schema/schema.json':
+  "stdout": "
+ ERROR  Error parsing 'packages/graphql-typescript-definitions/test/fixtures/missing-schema/schema.json':
 
 ENOENT: no such file or directory, open 'packages/graphql-typescript-definitions/test/fixtures/missing-schema/schema.json'
 Error: Error parsing 'packages/graphql-typescript-definitions/test/fixtures/missing-schema/schema.json':
@@ -90,10 +91,26 @@ Object {
   "error": null,
   "stderr": "",
   "stdout": "
- BUILT  packages/graphql-typescript-definitions/test/fixtures/missing-types/schema.ts
+ BUILT  packages/graphql-typescript-definitions/test/fixtures/missing-types/schema.json → packages/graphql-typescript-definitions/test/fixtures/missing-types/schema.ts
 
- BUILT  packages/graphql-typescript-definitions/test/fixtures/missing-types/documents/Query.graphql → packages/graphql-typescript-definitions/test/fixtures/missing-types/documents/Query.graphql.d.ts
  BUILT  packages/graphql-typescript-definitions/test/fixtures/missing-types/documents/Fragment.graphql → packages/graphql-typescript-definitions/test/fixtures/missing-types/documents/Fragment.graphql.d.ts
+ BUILT  packages/graphql-typescript-definitions/test/fixtures/missing-types/documents/Query.graphql → packages/graphql-typescript-definitions/test/fixtures/missing-types/documents/Query.graphql.d.ts
+",
+}
+`;
+
+exports[`cli succeeds when there are multiple schemas 1`] = `
+Object {
+  "error": null,
+  "stderr": "",
+  "stdout": "
+ BUILT  packages/graphql-typescript-definitions/test/fixtures/multiple-schemas/schema1/schema.json → packages/graphql-typescript-definitions/test/fixtures/multiple-schemas/schema1/schema.ts
+ BUILT  packages/graphql-typescript-definitions/test/fixtures/multiple-schemas/schema2/schema.json → packages/graphql-typescript-definitions/test/fixtures/multiple-schemas/schema2/schema.ts
+
+ BUILT  packages/graphql-typescript-definitions/test/fixtures/multiple-schemas/schema1/documents/Fragment.graphql → packages/graphql-typescript-definitions/test/fixtures/multiple-schemas/schema1/documents/Fragment.graphql.d.ts
+ BUILT  packages/graphql-typescript-definitions/test/fixtures/multiple-schemas/schema1/documents/Query.graphql → packages/graphql-typescript-definitions/test/fixtures/multiple-schemas/schema1/documents/Query.graphql.d.ts
+ BUILT  packages/graphql-typescript-definitions/test/fixtures/multiple-schemas/schema2/documents/Fragment.graphql → packages/graphql-typescript-definitions/test/fixtures/multiple-schemas/schema2/documents/Fragment.graphql.d.ts
+ BUILT  packages/graphql-typescript-definitions/test/fixtures/multiple-schemas/schema2/documents/Query.graphql → packages/graphql-typescript-definitions/test/fixtures/multiple-schemas/schema2/documents/Query.graphql.d.ts
 ",
 }
 `;
@@ -103,10 +120,10 @@ Object {
   "error": null,
   "stderr": "",
   "stdout": "
- BUILT  packages/graphql-typescript-definitions/test/fixtures/all-clear/schema.ts
+ BUILT  packages/graphql-typescript-definitions/test/fixtures/all-clear/schema.json → packages/graphql-typescript-definitions/test/fixtures/all-clear/schema.ts
 
- BUILT  packages/graphql-typescript-definitions/test/fixtures/all-clear/documents/Query.graphql → packages/graphql-typescript-definitions/test/fixtures/all-clear/documents/Query.graphql.d.ts
  BUILT  packages/graphql-typescript-definitions/test/fixtures/all-clear/documents/Fragment.graphql → packages/graphql-typescript-definitions/test/fixtures/all-clear/documents/Fragment.graphql.d.ts
+ BUILT  packages/graphql-typescript-definitions/test/fixtures/all-clear/documents/Query.graphql → packages/graphql-typescript-definitions/test/fixtures/all-clear/documents/Query.graphql.d.ts
 ",
 }
 `;

--- a/packages/graphql-typescript-definitions/test/cli.test.ts
+++ b/packages/graphql-typescript-definitions/test/cli.test.ts
@@ -13,6 +13,12 @@ describe('cli', () => {
     ).toMatchSnapshot();
   });
 
+  it('succeeds when there are multiple schemas', async () => {
+    expect(
+      await execDetails(cliCommandForFixtureDirectory('multiple-schemas')),
+    ).toMatchSnapshot();
+  });
+
   it('fails when there are syntax errors', async () => {
     expect(
       await execDetails(cliCommandForFixtureDirectory('malformed-query')),
@@ -51,8 +57,7 @@ function cliCommandForFixtureDirectory(fixture: string) {
   const fixtureDirectory = resolve(rootFixturePath, fixture);
   return [
     scriptPath,
-    `'${resolve(fixtureDirectory, 'documents/**/*.graphql')}'`,
-    `--schema-path '${resolve(fixtureDirectory, 'schema.json')}'`,
-    `--schema-types-path '${resolve(fixtureDirectory, 'schema.ts')}'`,
+    `--cwd '${fixtureDirectory}'`,
+    `--schema-types-path '${fixtureDirectory}'`,
   ].join(' ');
 }

--- a/packages/graphql-typescript-definitions/test/fixtures/all-clear/.graphqlconfig
+++ b/packages/graphql-typescript-definitions/test/fixtures/all-clear/.graphqlconfig
@@ -1,0 +1,7 @@
+{
+  "schemaPath": "schema.json",
+  "includes": ["documents/**/*.graphql"],
+  "extensions": {
+    "schemaTypesPath": "schema.ts"
+  }
+}

--- a/packages/graphql-typescript-definitions/test/fixtures/duplicate-names/.graphqlconfig
+++ b/packages/graphql-typescript-definitions/test/fixtures/duplicate-names/.graphqlconfig
@@ -1,0 +1,7 @@
+{
+  "schemaPath": "schema.json",
+  "includes": ["documents/**/*.graphql"],
+  "extensions": {
+    "schemaTypesPath": "schema.ts"
+  }
+}

--- a/packages/graphql-typescript-definitions/test/fixtures/malformed-query/.graphqlconfig
+++ b/packages/graphql-typescript-definitions/test/fixtures/malformed-query/.graphqlconfig
@@ -1,0 +1,7 @@
+{
+  "schemaPath": "schema.json",
+  "includes": ["documents/**/*.graphql"],
+  "extensions": {
+    "schemaTypesPath": "schema.ts"
+  }
+}

--- a/packages/graphql-typescript-definitions/test/fixtures/missing-schema/.graphqlconfig
+++ b/packages/graphql-typescript-definitions/test/fixtures/missing-schema/.graphqlconfig
@@ -1,0 +1,7 @@
+{
+  "schemaPath": "schema.json",
+  "includes": ["documents/**/*.graphql"],
+  "extensions": {
+    "schemaTypesPath": "schema.ts"
+  }
+}

--- a/packages/graphql-typescript-definitions/test/fixtures/missing-types/.graphqlconfig
+++ b/packages/graphql-typescript-definitions/test/fixtures/missing-types/.graphqlconfig
@@ -1,0 +1,7 @@
+{
+  "schemaPath": "schema.json",
+  "includes": ["documents/**/*.graphql"],
+  "extensions": {
+    "schemaTypesPath": "schema.ts"
+  }
+}

--- a/packages/graphql-typescript-definitions/test/fixtures/multiple-schemas/.graphqlconfig
+++ b/packages/graphql-typescript-definitions/test/fixtures/multiple-schemas/.graphqlconfig
@@ -1,0 +1,18 @@
+{
+  "projects": {
+    "test1": {
+      "schemaPath": "schema1/schema.json",
+      "includes": ["schema1/documents/**/*.graphql"],
+      "extensions": {
+        "schemaTypesPath": "schema1/schema.ts"
+      }
+    },
+    "test2": {
+      "schemaPath": "schema2/schema.json",
+      "includes": ["schema2/documents/**/*.graphql"],
+      "extensions": {
+        "schemaTypesPath": "schema2/schema.ts"
+      }
+    }
+  }
+}

--- a/packages/graphql-typescript-definitions/test/fixtures/multiple-schemas/schema1/documents/Fragment.graphql
+++ b/packages/graphql-typescript-definitions/test/fixtures/multiple-schemas/schema1/documents/Fragment.graphql
@@ -1,0 +1,7 @@
+fragment PersonFields1 on Person1 {
+  name
+  generation
+  relatives {
+    name
+  }
+}

--- a/packages/graphql-typescript-definitions/test/fixtures/multiple-schemas/schema1/documents/Query.graphql
+++ b/packages/graphql-typescript-definitions/test/fixtures/multiple-schemas/schema1/documents/Query.graphql
@@ -1,0 +1,6 @@
+query FindPerson1 {
+  person {
+    id
+    ...PersonFields1
+  }
+}

--- a/packages/graphql-typescript-definitions/test/fixtures/multiple-schemas/schema1/schema.graphql
+++ b/packages/graphql-typescript-definitions/test/fixtures/multiple-schemas/schema1/schema.graphql
@@ -1,0 +1,19 @@
+enum Generation1 {
+  MILLENIAL
+  GEN_X
+}
+
+type Person1 {
+  id: ID!
+  name: String!
+  generation: Generation1!
+  relatives: [Person1!]!
+}
+
+type Query1 {
+  person: Person1
+}
+
+schema {
+  query: Query1
+}

--- a/packages/graphql-typescript-definitions/test/fixtures/multiple-schemas/schema2/documents/Fragment.graphql
+++ b/packages/graphql-typescript-definitions/test/fixtures/multiple-schemas/schema2/documents/Fragment.graphql
@@ -1,0 +1,7 @@
+fragment PersonFields2 on Person2 {
+  name
+  generation
+  relatives {
+    name
+  }
+}

--- a/packages/graphql-typescript-definitions/test/fixtures/multiple-schemas/schema2/documents/Query.graphql
+++ b/packages/graphql-typescript-definitions/test/fixtures/multiple-schemas/schema2/documents/Query.graphql
@@ -1,0 +1,6 @@
+query FindPerson2 {
+  person {
+    id
+    ...PersonFields2
+  }
+}

--- a/packages/graphql-typescript-definitions/test/fixtures/multiple-schemas/schema2/schema.graphql
+++ b/packages/graphql-typescript-definitions/test/fixtures/multiple-schemas/schema2/schema.graphql
@@ -1,0 +1,19 @@
+enum Generation2 {
+  MILLENIAL
+  GEN_X
+}
+
+type Person2 {
+  id: ID!
+  name: String!
+  generation: Generation2!
+  relatives: [Person2!]!
+}
+
+type Query2 {
+  person: Person2
+}
+
+schema {
+  query: Query2
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "noUnusedParameters": true,
     "experimentalDecorators": true,
     "target": "es2015",
-    "lib": ["es2015", "es2016", "es2017", "esnext.asynciterable"]
+    "lib": ["dom", "es2015", "es2016", "es2017", "esnext.asynciterable"]
   },
   "include": ["./test/setup.ts", "./**/*.ts"],
   "exclude": ["./**/node_modules", "./**/*.graphql.d.ts"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -1425,6 +1425,13 @@ cross-fetch@2.0.0:
     node-fetch "2.0.0"
     whatwg-fetch "2.0.3"
 
+cross-fetch@2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-2.2.2.tgz#a47ff4f7fc712daba8f6a695a11c948440d45723"
+  dependencies:
+    node-fetch "2.1.2"
+    whatwg-fetch "2.0.4"
+
 cross-spawn@^4.0.0:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-4.0.2.tgz#7b9247621c23adfdd3856004a823cbe397424d41"
@@ -2491,7 +2498,17 @@ graphql-config@^1.1.1:
     lodash "^4.17.4"
     minimatch "^3.0.4"
 
-graphql-import@^0.4.0:
+graphql-config@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/graphql-config/-/graphql-config-2.1.0.tgz#f07107ac44b661282d2002497de588f01aa92c9d"
+  dependencies:
+    graphql-import "^0.4.4"
+    graphql-request "^1.5.0"
+    js-yaml "^3.10.0"
+    lodash "^4.17.4"
+    minimatch "^3.0.4"
+
+graphql-import@^0.4.0, graphql-import@^0.4.4:
   version "0.4.5"
   resolved "https://registry.yarnpkg.com/graphql-import/-/graphql-import-0.4.5.tgz#e2f18c28d335733f46df8e0733d8deb1c6e2a645"
   dependencies:
@@ -2502,6 +2519,12 @@ graphql-request@^1.4.0:
   resolved "https://registry.yarnpkg.com/graphql-request/-/graphql-request-1.6.0.tgz#afe87cf2a336acabb0cc2a875900202eda89f412"
   dependencies:
     cross-fetch "2.0.0"
+
+graphql-request@^1.5.0:
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/graphql-request/-/graphql-request-1.8.2.tgz#398d10ae15c585676741bde3fc01d5ca948f8fbe"
+  dependencies:
+    cross-fetch "2.2.2"
 
 graphql@0.13.2, graphql@^0.13.1, graphql@^0.13.2:
   version "0.13.2"
@@ -4009,6 +4032,10 @@ no-case@^2.2.0, no-case@^2.3.2:
 node-fetch@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.0.0.tgz#982bba43ecd4f2922a29cc186a6bbb0bb73fcba6"
+
+node-fetch@2.1.2:
+  version "2.1.2"
+  resolved "http://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
 
 node-fetch@^1.0.1, node-fetch@^1.7.3:
   version "1.7.3"
@@ -5566,7 +5593,7 @@ whatwg-fetch@2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz#9c84ec2dcf68187ff00bc64e1274b442176e1c84"
 
-whatwg-fetch@>=0.10.0:
+whatwg-fetch@2.0.4, whatwg-fetch@>=0.10.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz#dde6a5df315f9d39991aa17621853d720b85566f"
 


### PR DESCRIPTION
Prior to this PR, this tool was only capable of processing a single schema within a workspace. The [Prisma `.graphqlconfig` (`graphql-config`)](https://github.com/prisma/graphql-config) format is gaining community support (see the [VSCode extension](https://github.com/prisma/vscode-graphql)) and is much more expressive, specifically in handling multiple schemas. This PR is mostly a drop in replacement, only requiring a small migration from the old `.gqlconfig` to the new `.graphqlconfig` format on consumer projects.

The intergration of `graphql-config` essentially builds a workspace `GraphQLConfig` and queries this instance whenever we want to process a graphql file (query, mutation, fragment, or schema). The top level config instance holds a collection of projects, each project is linked to a schema and includes/excludes glob lists. Project configs also support an `extensions` _sandbox_ element that we can optionally use to configure a custom schema types output path (see `schemaTypesPath` below). Our workspace config can tell us which project a file matches with (though glob intersection can cause problems, see *caveats* section below).

Any included files (typically these would be `*.graphql` are processed into `*.graphql.d.ts`. Schema files are only processed into schema types (either `types.ts` for nameless projects, or `${projectName}-types.ts` for named projects) but this can be overridden by adding a `schemaTypesPath` extension with the path to use instead which allows customization over the name of the schema types file (see below for an example). The `graphql-config` tooling supports linking a project to either `schema.json` or `schema.graphql`.

CLI output has been cleaned up a little as well, primarily to produce consistent and deterministic output. This is achieved by buffering outputs from `build` events (first clearing buffers on `start` events) and printing them in order on `end` events.

the `dom` lib has been added to the `tsconfig.json`. Normally, this is not suggested for a node project, however in this case our `graphql-config` dependency (and by extension, its dependency `graphql-request`) expects the `dom` lib. Additionally, Sewing Kit [also uses dom](https://github.com/Shopify/sewing-kit/blob/master/tsconfig.json#L8) so we don't have much of a choice in the matter here.

### ⚠️ Caveats

* glob intersections can cause unpredictable behaviour. The first project that matches a file will be used for schema linking, which depends on the `GraphQLConfig.getProjects` function, which is iterating the configured projects. This could mean that naming of projects in `.graphqlconfig` could have an effect on runtime execution. A workaround to prevent this is to use globs that are namespaced enough to prevent overlap or add excludes to projects with wide reaching include globs.
* [globbing does not support absolute paths](https://github.com/stephen/vscode-graphql/issues/23). the globbing in `graphql-config` will reduce files to match to relative paths against the `.graphqlconfig` file, and the globbing tool (`minimatch`) cannot match a relative file against an absolute glob pattern. The workaround to prevent this is to simply use relative globs.

### 🎩  Instructions for `sewing-kit`

`yarn --cwd packages/graphql-typescript-definitions build && cp -R packages/graphql-typescript-definitions/lib/* ~/src/github.com/Shopify/sewing-kit/node_modules/graphql-typescript-definitions/lib/`

### 🎩  Instructions for `web`

(may vary depeding on where you store project locally)

`yarn --cwd packages/graphql-typescript-definitions build && cp -R packages/graphql-typescript-definitions/lib/* ~/src/github.com/Shopify/web/node_modules/\@shopify/sewing-kit/node_modules/graphql-typescript-definitions/lib/`

You may want to also install the [Prisma VSCode Extension](https://marketplace.visualstudio.com/items?itemName=Prisma.vscode-graphql) to see the tooling provide hover text, auto-complete, and intellisense to `*.graphql` files.

I have 🎩'd this with `web` with the `.graphqlconfig` below and everything worked as expected. The custom schema does not get validated against the core schema. The custom schema types file is generated (`{projectName}-types.ts`).

```json
{
  "projects": {
    "bourgeois": {
      "schemaPath": "app/sections/Capital/graphql/bourgeois/schema.json",
      "includes": ["app/sections/Capital/**/graphql/bourgeois/*.graphql"]
    },
    "core": {
      "schemaPath": "build/schema.json",
      "includes": ["app/**/*.graphql"],
      "excludes": ["app/**/graphql/bourgeois/*.graphql"],
      "extensions": {
        "schemaTypesPath": "app/types/graphql.ts"
      }
    }
  }
}
```