### PR TITLE
fixing incorrect usage of schemaTypesPath

### DIFF
--- a/packages/graphql-typescript-definitions/src/index.ts
+++ b/packages/graphql-typescript-definitions/src/index.ts
@@ -280,9 +280,7 @@ export class Builder extends EventEmitter {
     try {
       return printDocument(file, ast, {
         ...this.options,
-        schemaTypesPath:
-          this.options.schemaTypesPath ||
-          getSchemaTypesPath(project, this.options),
+        schemaTypesPath: getSchemaTypesPath(project, this.options),
       });
     } catch ({message}) {
       const error = new Error(


### PR DESCRIPTION
In earlier versions of the `graphql-config` patch the `schemaTypesPath` option was used to specify the path to a single schema types file. The current usage is to provide the directory path where schema types will be written. Routine 🎩ing didn't pick this one up as the graphql generated typings do not generate errors if the import is invalid.

The fix is to simply use the built-in `getSchemaTypesPath` function to resolve the proper schema types path for the project/schema belonging to the document being written.