### PR TITLE
updating graphql-validate-fixtures to support graphql-config

### DIFF
--- a/packages/graphql-tool-utilities/config.ts
+++ b/packages/graphql-tool-utilities/config.ts
@@ -23,14 +23,11 @@ export function getGraphQLProjects(config: GraphQLConfig) {
 }
 
 export function getGraphQLSchemaPaths(config: GraphQLConfig) {
-  return getGraphQLProjects(config).reduce<string[]>(
-    (schemas, {schemaPath}) => {
-      return schemaPath
-        ? schemas.concat(getGraphQLFilePath(config, schemaPath))
-        : schemas;
-    },
-    [],
-  );
+  return getGraphQLProjects(config).reduce<string[]>((schemas, project) => {
+    return schemas.concat(
+      getGraphQLFilePath(config, project.resolveSchemaPath()),
+    );
+  }, []);
 }
 
 export function getGraphQLProjectForSchemaPath(
@@ -38,7 +35,7 @@ export function getGraphQLProjectForSchemaPath(
   schemaPath: string,
 ) {
   const project =
-    Object.values(config.getProjects() || {})
+    getGraphQLProjects(config)
       .filter((project) => project.schemaPath === schemaPath)
       .shift() || config.getProjectConfig();
 

--- a/packages/graphql-typescript-definitions/src/index.ts
+++ b/packages/graphql-typescript-definitions/src/index.ts
@@ -20,18 +20,18 @@ import {
   GraphQLConfig,
 } from 'graphql-config';
 import {
+  getGraphQLFilePath,
+  getGraphQLProjectForSchemaPath,
+  getGraphQLProjects,
+  getGraphQLSchemaPaths,
+} from 'graphql-tool-utilities';
+import {
   compile,
   isOperation,
   Operation,
   Fragment,
   AST,
 } from 'graphql-tool-utilities/ast';
-import {
-  getGraphQLFilePath,
-  getGraphQLProjectForSchemaPath,
-  getGraphQLProjects,
-  getGraphQLSchemaPaths,
-} from 'graphql-tool-utilities/config';
 
 import {printDocument, printSchema} from './print';
 import {EnumFormat} from './types';

--- a/packages/graphql-validate-fixtures/README.md
+++ b/packages/graphql-validate-fixtures/README.md
@@ -23,13 +23,26 @@ In order to associate a fixture with a GraphQL query or mutation in your app, yo
 
 Once this is done, you can validate your fixtures using the CLI or Node.js API.
 
+### Operation
+
+On startup this tool performs the following actions:
+
+* Loads all schemas
+* Discovers all operations belonging to each schema
+* Discovers all fixtures and infers operation names as described [above](#Usage)
+* Validates fixtures against the operation with a matching name
+  * Reports operation not found error if no schema matches
+  * Reports ambiguous operation name error if more than one schema matches
+
+### Configuration
+
+This tool reads schema information from a [`.graphqlconfig`](https://github.com/Shopify/graphql-tools-web/tree/master/packages/graphql-tool-utilities#configuration) file in the project root.
+
 ### CLI
 
 ```sh
-# Must provide a list of fixtures as the first argument, as well
-# as flags for the path to the schema (`--schema-path`) and operations
-# (`--operation-paths`, can be a glob pattern)
-yarn run graphql-validate-fixtures 'src/**/fixtures/**/*.graphql.json' --schema-path 'build/schema.json' --operation-paths 'src/**/*.graphql'
+# Must provide a list of fixtures as the first argument
+yarn run graphql-validate-fixtures 'src/**/fixtures/**/*.graphql.json'
 ```
 
 ### Node
@@ -38,12 +51,9 @@ yarn run graphql-validate-fixtures 'src/**/fixtures/**/*.graphql.json' --schema-
 const {evaluateFixtures} = require('graphql-validate-fixtures');
 evaluateFixtures({
   fixturePaths: ['test/fixtures/one.json', 'test/fixtures/two.json'],
-  schemaPath: 'build/schema.json',
-  operationPaths: ['src/Home/Home.graphql'],
-})
-  .then((results) => {
-    // See the TypeScript definition file for more details on the
-    // structure of the `results`
-    results.forEach((result) => console.log(result));
-  });
+}).then((results) => {
+  // See the TypeScript definition file for more details on the
+  // structure of the `results`
+  results.forEach((result) => console.log(result));
+});
 ```

--- a/packages/graphql-validate-fixtures/src/cli.ts
+++ b/packages/graphql-validate-fixtures/src/cli.ts
@@ -9,25 +9,12 @@ import {evaluateFixtures} from '.';
 
 const argv = yargs
   .usage('Usage: $0 <fixtures> [options]')
-  .option('schema-path', {
-    required: true,
-    normalize: true,
-    type: 'string',
-    describe:
-      'The path to the JSON file containing a schema instrospection query result',
-  })
-  .option('operation-paths', {
+  .option('cwd', {
     required: false,
+    default: process.cwd(),
     normalize: true,
     type: 'string',
-    describe:
-      'The glob pattern for GraphQL queries and fragments to compare against',
-  })
-  .option('schema-only', {
-    type: 'boolean',
-    default: false,
-    describe:
-      'Validate fixtures only against the GraphQL schema (and not any query or mutation documents)',
+    describe: 'Working directory where the .graphqlconfig is located',
   })
   .option('show-passes', {
     type: 'boolean',
@@ -37,18 +24,9 @@ const argv = yargs
   })
   .help().argv;
 
-const hasOperationPaths = Boolean(argv.operationPaths);
-
-evaluateFixtures(
-  {
-    fixturePaths: glob.sync(argv._[0]),
-    operationPaths: hasOperationPaths ? glob.sync(argv.operationPaths) : [],
-    schemaPath: argv.schemaPath,
-  },
-  {
-    schemaOnly: argv.schemaOnly || !hasOperationPaths,
-  },
-)
+evaluateFixtures(glob.sync(argv._[0]), {
+  cwd: argv.cwd,
+})
   .then((evaluations) => {
     let passed = 0;
     let failed = 0;
@@ -57,7 +35,7 @@ evaluateFixtures(
     console.log();
 
     evaluations.forEach((evaluation) => {
-      const relativePath = relative(process.cwd(), evaluation.fixturePath);
+      const relativePath = relative(argv.cwd, evaluation.fixturePath);
       const formattedPath = `${chalk.dim(
         relativePath.replace(basename(relativePath), ''),
       )}${chalk.bold(basename(relativePath))}`;

--- a/packages/graphql-validate-fixtures/test/__snapshots__/cli.test.ts.snap
+++ b/packages/graphql-validate-fixtures/test/__snapshots__/cli.test.ts.snap
@@ -1,12 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`cli fails when there are fixture errors 1`] = `"Command failed: packages/graphql-validate-fixtures/bin/graphql-validate-fixtures 'packages/graphql-validate-fixtures/test/fixtures/fixture-errors/fixtures/**/*.json' --schema-path 'packages/graphql-validate-fixtures/test/fixtures/fixture-errors/schema.json' --operation-paths 'packages/graphql-validate-fixtures/test/fixtures/fixture-errors/queries/**/*.graphql'"`;
+exports[`cli fails when a fixture matches no operations 1`] = `"Command failed: packages/graphql-validate-fixtures/bin/graphql-validate-fixtures 'packages/graphql-validate-fixtures/test/fixtures/missing-operation/fixtures/**/*.json' --cwd 'packages/graphql-validate-fixtures/test/fixtures/missing-operation'"`;
 
-exports[`cli fails when there are syntax errors 1`] = `"Command failed: packages/graphql-validate-fixtures/bin/graphql-validate-fixtures 'packages/graphql-validate-fixtures/test/fixtures/fixture-invalid/fixtures/**/*.json' --schema-path 'packages/graphql-validate-fixtures/test/fixtures/fixture-invalid/schema.json' --operation-paths 'packages/graphql-validate-fixtures/test/fixtures/fixture-invalid/queries/**/*.graphql'"`;
+exports[`cli fails when there are ambiguous fixture names 1`] = `"Command failed: packages/graphql-validate-fixtures/bin/graphql-validate-fixtures 'packages/graphql-validate-fixtures/test/fixtures/ambiguous-operation/fixtures/**/*.json' --cwd 'packages/graphql-validate-fixtures/test/fixtures/ambiguous-operation'"`;
 
-exports[`cli fails when there are syntax errors 2`] = `"Command failed: packages/graphql-validate-fixtures/bin/graphql-validate-fixtures 'packages/graphql-validate-fixtures/test/fixtures/malformed-query/fixtures/**/*.json' --schema-path 'packages/graphql-validate-fixtures/test/fixtures/malformed-query/schema.json' --operation-paths 'packages/graphql-validate-fixtures/test/fixtures/malformed-query/queries/**/*.graphql'"`;
+exports[`cli fails when there are fixture errors 1`] = `"Command failed: packages/graphql-validate-fixtures/bin/graphql-validate-fixtures 'packages/graphql-validate-fixtures/test/fixtures/fixture-errors/fixtures/**/*.json' --cwd 'packages/graphql-validate-fixtures/test/fixtures/fixture-errors'"`;
 
-exports[`cli fails when there are syntax errors 3`] = `"Command failed: packages/graphql-validate-fixtures/bin/graphql-validate-fixtures 'packages/graphql-validate-fixtures/test/fixtures/missing-schema/fixtures/**/*.json' --schema-path 'packages/graphql-validate-fixtures/test/fixtures/missing-schema/schema.json' --operation-paths 'packages/graphql-validate-fixtures/test/fixtures/missing-schema/queries/**/*.graphql'"`;
+exports[`cli fails when there are syntax errors 1`] = `"Command failed: packages/graphql-validate-fixtures/bin/graphql-validate-fixtures 'packages/graphql-validate-fixtures/test/fixtures/fixture-invalid/fixtures/**/*.json' --cwd 'packages/graphql-validate-fixtures/test/fixtures/fixture-invalid'"`;
+
+exports[`cli fails when there are syntax errors 2`] = `"Command failed: packages/graphql-validate-fixtures/bin/graphql-validate-fixtures 'packages/graphql-validate-fixtures/test/fixtures/malformed-query/fixtures/**/*.json' --cwd 'packages/graphql-validate-fixtures/test/fixtures/malformed-query'"`;
+
+exports[`cli fails when there are syntax errors 3`] = `"Command failed: packages/graphql-validate-fixtures/bin/graphql-validate-fixtures 'packages/graphql-validate-fixtures/test/fixtures/missing-schema/fixtures/**/*.json' --cwd 'packages/graphql-validate-fixtures/test/fixtures/missing-schema'"`;
 
 exports[`cli hides passing fixtures by default 1`] = `
 "
@@ -17,9 +21,9 @@ exports[`cli hides passing fixtures by default 1`] = `
 
 exports[`cli shows passes fixtures when the show-passes flag is true 1`] = `
 "
- PASS  packages/graphql-validate-fixtures/test/fixtures/all-clear/fixtures/another-another-fixture.json
- PASS  packages/graphql-validate-fixtures/test/fixtures/all-clear/fixtures/another-fixture.json
- PASS  packages/graphql-validate-fixtures/test/fixtures/all-clear/fixtures/MyQuery/fixture.json
+ PASS  fixtures/another-another-fixture.json
+ PASS  fixtures/another-fixture.json
+ PASS  fixtures/MyQuery/fixture.json
 
 3 passed
 "

--- a/packages/graphql-validate-fixtures/test/__snapshots__/index.test.ts.snap
+++ b/packages/graphql-validate-fixtures/test/__snapshots__/index.test.ts.snap
@@ -1,5 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`evaluateFixtures() handles ambiguous operation names in multi-project fixtures with errors 1`] = `
+Array [
+  Object {
+    "fixturePath": "packages/graphql-validate-fixtures/test/fixtures/ambiguous-operation/fixtures/projectA/AmbiguousQuery/fixture.json",
+    "validationErrors": Array [
+      [Error: Ambiguous operation name found for 'packages/graphql-validate-fixtures/test/fixtures/ambiguous-operation/fixtures/projectA/AmbiguousQuery/fixture.json' (found Ambiguous) in projects: projectA, projectB. Try renaming the operation in one of the projects listed and updating the fixture folder name or use an '@operation' key indicating the new operation name.],
+    ],
+  },
+  Object {
+    "fixturePath": "packages/graphql-validate-fixtures/test/fixtures/ambiguous-operation/fixtures/projectB/AmbiguousQuery/fixture.json",
+    "validationErrors": Array [
+      [Error: Ambiguous operation name found for 'packages/graphql-validate-fixtures/test/fixtures/ambiguous-operation/fixtures/projectB/AmbiguousQuery/fixture.json' (found Ambiguous) in projects: projectA, projectB. Try renaming the operation in one of the projects listed and updating the fixture folder name or use an '@operation' key indicating the new operation name.],
+    ],
+  },
+]
+`;
+
 exports[`evaluateFixtures() handles fixtures that are invalid json 1`] = `
 Array [
   Object {
@@ -9,7 +26,7 @@ Array [
   },
   Object {
     "fixturePath": "packages/graphql-validate-fixtures/test/fixtures/fixture-invalid/fixtures/MyQuery/fixture.json",
-    "operationName": "MyQuery",
+    "operationName": "My",
     "operationPath": "packages/graphql-validate-fixtures/test/fixtures/fixture-invalid/queries/Query.graphql",
     "operationType": "query",
     "validationErrors": Array [],
@@ -21,7 +38,7 @@ exports[`evaluateFixtures() handles fixtures with errors 1`] = `
 Array [
   Object {
     "fixturePath": "packages/graphql-validate-fixtures/test/fixtures/fixture-errors/fixtures/another-fixture.json",
-    "operationName": "AnotherQuery",
+    "operationName": "Another",
     "operationPath": "packages/graphql-validate-fixtures/test/fixtures/fixture-errors/queries/Another.graphql",
     "operationType": "query",
     "validationErrors": Array [
@@ -37,7 +54,7 @@ Array [
   },
   Object {
     "fixturePath": "packages/graphql-validate-fixtures/test/fixtures/fixture-errors/fixtures/MyQuery/fixture.json",
-    "operationName": "MyQuery",
+    "operationName": "My",
     "operationPath": "packages/graphql-validate-fixtures/test/fixtures/fixture-errors/queries/Query.graphql",
     "operationType": "query",
     "validationErrors": Array [],
@@ -56,14 +73,14 @@ Array [
   },
   Object {
     "fixturePath": "packages/graphql-validate-fixtures/test/fixtures/all-clear/fixtures/another-fixture.json",
-    "operationName": "AnotherQuery",
+    "operationName": "Another",
     "operationPath": "packages/graphql-validate-fixtures/test/fixtures/all-clear/queries/Another.graphql",
     "operationType": "query",
     "validationErrors": Array [],
   },
   Object {
     "fixturePath": "packages/graphql-validate-fixtures/test/fixtures/all-clear/fixtures/MyQuery/fixture.json",
-    "operationName": "MyQuery",
+    "operationName": "My",
     "operationPath": "packages/graphql-validate-fixtures/test/fixtures/all-clear/queries/Query.graphql",
     "operationType": "query",
     "validationErrors": Array [],
@@ -71,32 +88,38 @@ Array [
 ]
 `;
 
-exports[`evaluateFixtures() schemaOnly does not fail on malformed GraphQL documents 1`] = `
+exports[`evaluateFixtures() handles missing operation names in multi-project fixtures with errors 1`] = `
 Array [
   Object {
-    "fixturePath": "packages/graphql-validate-fixtures/test/fixtures/malformed-query/fixtures/another-fixture.json",
+    "fixturePath": "packages/graphql-validate-fixtures/test/fixtures/missing-operation/fixtures/projectA/AQuery/fixture.json",
+    "operationName": "A",
+    "operationPath": "packages/graphql-validate-fixtures/test/fixtures/missing-operation/queries/projectA/Query.graphql",
+    "operationType": "query",
     "validationErrors": Array [],
   },
   Object {
-    "fixturePath": "packages/graphql-validate-fixtures/test/fixtures/malformed-query/fixtures/MyQuery/fixture.json",
-    "validationErrors": Array [],
+    "fixturePath": "packages/graphql-validate-fixtures/test/fixtures/missing-operation/fixtures/projectB/Missing/fixture.json",
+    "validationErrors": Array [
+      [Error: Could not find a matching operation for 'packages/graphql-validate-fixtures/test/fixtures/missing-operation/fixtures/projectB/Missing/fixture.json' (looked for Missing). Make sure to put your fixture in a folder named the same as the operation, or add an '@operation' key indicating the operation. Available operations: A, B],
+    ],
   },
 ]
 `;
 
-exports[`evaluateFixtures() schemaOnly validates against the schema only 1`] = `
+exports[`evaluateFixtures() handles multi-project fixtures without errors 1`] = `
 Array [
   Object {
-    "fixturePath": "packages/graphql-validate-fixtures/test/fixtures/fixture-errors/fixtures/another-fixture.json",
-    "validationErrors": Array [
-      Object {
-        "keyPath": "name",
-        "message": "should be a string but was a number",
-      },
-    ],
+    "fixturePath": "packages/graphql-validate-fixtures/test/fixtures/multi-project/fixtures/projectA/AQuery/fixture.json",
+    "operationName": "A",
+    "operationPath": "packages/graphql-validate-fixtures/test/fixtures/multi-project/queries/projectA/Query.graphql",
+    "operationType": "query",
+    "validationErrors": Array [],
   },
   Object {
-    "fixturePath": "packages/graphql-validate-fixtures/test/fixtures/fixture-errors/fixtures/MyQuery/fixture.json",
+    "fixturePath": "packages/graphql-validate-fixtures/test/fixtures/multi-project/fixtures/projectB/BQuery/fixture.json",
+    "operationName": "B",
+    "operationPath": "packages/graphql-validate-fixtures/test/fixtures/multi-project/queries/projectB/Query.graphql",
+    "operationType": "query",
     "validationErrors": Array [],
   },
 ]

--- a/packages/graphql-validate-fixtures/test/__snapshots__/validate.test.ts.snap
+++ b/packages/graphql-validate-fixtures/test/__snapshots__/validate.test.ts.snap
@@ -1735,31 +1735,3 @@ Object {
   ],
 }
 `;
-
-exports[`validate validateFixtureAgainstSchema() validates fields against types from the schema 1`] = `
-Object {
-  "fixturePath": "fixture.json",
-  "validationErrors": Array [
-    Object {
-      "keyPath": "person.age",
-      "message": "should be an integer but was a float",
-    },
-    Object {
-      "keyPath": "person.silly",
-      "message": "does not exist on type Person (available fields: name, age, occupation, nickNames)",
-    },
-    Object {
-      "keyPath": "person.nickNames",
-      "message": "should be an array (or null), but was an object",
-    },
-    Object {
-      "keyPath": "friends[0].firstName",
-      "message": "does not exist on type Person (available fields: name, age, occupation, nickNames)",
-    },
-    Object {
-      "keyPath": "friends[1].name",
-      "message": "should be non-null but was null",
-    },
-  ],
-}
-`;

--- a/packages/graphql-validate-fixtures/test/cli.test.ts
+++ b/packages/graphql-validate-fixtures/test/cli.test.ts
@@ -12,6 +12,24 @@ describe('cli', () => {
     ).not.toThrowError();
   });
 
+  it('succeeds for a multi-project when there are no fixture errors', () => {
+    expect(() =>
+      exec(cliCommandForFixtureDirectory('multi-project')),
+    ).not.toThrowError();
+  });
+
+  it('fails when there are ambiguous fixture names', () => {
+    expect(() =>
+      exec(cliCommandForFixtureDirectory('ambiguous-operation')),
+    ).toThrowErrorMatchingSnapshot();
+  });
+
+  it('fails when a fixture matches no operations', () => {
+    expect(() =>
+      exec(cliCommandForFixtureDirectory('missing-operation')),
+    ).toThrowErrorMatchingSnapshot();
+  });
+
   it('fails when there are fixture errors', () => {
     expect(() =>
       exec(cliCommandForFixtureDirectory('fixture-errors')),
@@ -61,8 +79,7 @@ function cliCommandForFixtureDirectory(fixture: string, showPasses = false) {
   return [
     scriptPath,
     `'${resolve(fixtureDirectory, 'fixtures/**/*.json')}'`,
-    `--schema-path '${resolve(fixtureDirectory, 'schema.json')}'`,
-    `--operation-paths '${resolve(fixtureDirectory, 'queries/**/*.graphql')}'`,
+    `--cwd '${fixtureDirectory}'`,
     showPasses ? `--show-passes` : '',
   ]
     .join(' ')

--- a/packages/graphql-validate-fixtures/test/fixtures/all-clear/.graphqlconfig.yml
+++ b/packages/graphql-validate-fixtures/test/fixtures/all-clear/.graphqlconfig.yml
@@ -1,0 +1,4 @@
+schemaPath: schema.json
+includes:
+  - schema.graphql
+  - queries/**/*.graphql

--- a/packages/graphql-validate-fixtures/test/fixtures/ambiguous-operation/.graphqlconfig.yml
+++ b/packages/graphql-validate-fixtures/test/fixtures/ambiguous-operation/.graphqlconfig.yml
@@ -1,0 +1,9 @@
+projects:
+  projectA:
+    schemaPath: projectA-schema.graphql
+    includes:
+      - queries/projectA/**/*.graphql
+  projectB:
+    schemaPath: projectB-schema.graphql
+    includes:
+      - queries/projectB/**/*.graphql

--- a/packages/graphql-validate-fixtures/test/fixtures/ambiguous-operation/fixtures/projectA/AmbiguousQuery/fixture.json
+++ b/packages/graphql-validate-fixtures/test/fixtures/ambiguous-operation/fixtures/projectA/AmbiguousQuery/fixture.json
@@ -1,0 +1,3 @@
+{
+  "nameA": "Chris"
+}

--- a/packages/graphql-validate-fixtures/test/fixtures/ambiguous-operation/fixtures/projectB/AmbiguousQuery/fixture.json
+++ b/packages/graphql-validate-fixtures/test/fixtures/ambiguous-operation/fixtures/projectB/AmbiguousQuery/fixture.json
@@ -1,0 +1,3 @@
+{
+  "nameB": "Chris"
+}

--- a/packages/graphql-validate-fixtures/test/fixtures/ambiguous-operation/projectA-schema.graphql
+++ b/packages/graphql-validate-fixtures/test/fixtures/ambiguous-operation/projectA-schema.graphql
@@ -1,0 +1,7 @@
+type Query {
+  nameA: String!
+}
+
+schema {
+  query: Query
+}

--- a/packages/graphql-validate-fixtures/test/fixtures/ambiguous-operation/projectB-schema.graphql
+++ b/packages/graphql-validate-fixtures/test/fixtures/ambiguous-operation/projectB-schema.graphql
@@ -1,0 +1,7 @@
+type Query {
+  nameB: String!
+}
+
+schema {
+  query: Query
+}

--- a/packages/graphql-validate-fixtures/test/fixtures/ambiguous-operation/queries/projectA/Ambiguous.graphql
+++ b/packages/graphql-validate-fixtures/test/fixtures/ambiguous-operation/queries/projectA/Ambiguous.graphql
@@ -1,0 +1,3 @@
+query Ambiguous {
+  nameA
+}

--- a/packages/graphql-validate-fixtures/test/fixtures/ambiguous-operation/queries/projectB/Ambiguous.graphql
+++ b/packages/graphql-validate-fixtures/test/fixtures/ambiguous-operation/queries/projectB/Ambiguous.graphql
@@ -1,0 +1,3 @@
+query Ambiguous {
+  nameB
+}

--- a/packages/graphql-validate-fixtures/test/fixtures/fixture-errors/.graphqlconfig.yml
+++ b/packages/graphql-validate-fixtures/test/fixtures/fixture-errors/.graphqlconfig.yml
@@ -1,0 +1,4 @@
+schemaPath: schema.json
+includes:
+  - schema.graphql
+  - queries/**/*.graphql

--- a/packages/graphql-validate-fixtures/test/fixtures/fixture-invalid/.graphqlconfig.yml
+++ b/packages/graphql-validate-fixtures/test/fixtures/fixture-invalid/.graphqlconfig.yml
@@ -1,0 +1,4 @@
+schemaPath: schema.json
+includes:
+  - schema.graphql
+  - queries/**/*.graphql

--- a/packages/graphql-validate-fixtures/test/fixtures/malformed-query/.graphqlconfig.yml
+++ b/packages/graphql-validate-fixtures/test/fixtures/malformed-query/.graphqlconfig.yml
@@ -1,0 +1,4 @@
+schemaPath: schema.json
+includes:
+  - schema.graphql
+  - queries/**/*.graphql

--- a/packages/graphql-validate-fixtures/test/fixtures/missing-operation/.graphqlconfig.yml
+++ b/packages/graphql-validate-fixtures/test/fixtures/missing-operation/.graphqlconfig.yml
@@ -1,0 +1,9 @@
+projects:
+  projectA:
+    schemaPath: projectA-schema.graphql
+    includes:
+      - queries/projectA/**/*.graphql
+  projectB:
+    schemaPath: projectB-schema.graphql
+    includes:
+      - queries/projectB/**/*.graphql

--- a/packages/graphql-validate-fixtures/test/fixtures/missing-operation/fixtures/projectA/AQuery/fixture.json
+++ b/packages/graphql-validate-fixtures/test/fixtures/missing-operation/fixtures/projectA/AQuery/fixture.json
@@ -1,0 +1,3 @@
+{
+  "nameA": "Chris"
+}

--- a/packages/graphql-validate-fixtures/test/fixtures/missing-operation/fixtures/projectB/Missing/fixture.json
+++ b/packages/graphql-validate-fixtures/test/fixtures/missing-operation/fixtures/projectB/Missing/fixture.json
@@ -1,0 +1,3 @@
+{
+  "nameB": "Chris"
+}

--- a/packages/graphql-validate-fixtures/test/fixtures/missing-operation/projectA-schema.graphql
+++ b/packages/graphql-validate-fixtures/test/fixtures/missing-operation/projectA-schema.graphql
@@ -1,0 +1,7 @@
+type Query {
+  nameA: String!
+}
+
+schema {
+  query: Query
+}

--- a/packages/graphql-validate-fixtures/test/fixtures/missing-operation/projectB-schema.graphql
+++ b/packages/graphql-validate-fixtures/test/fixtures/missing-operation/projectB-schema.graphql
@@ -1,0 +1,7 @@
+type Query {
+  nameB: String!
+}
+
+schema {
+  query: Query
+}

--- a/packages/graphql-validate-fixtures/test/fixtures/missing-operation/queries/projectA/Query.graphql
+++ b/packages/graphql-validate-fixtures/test/fixtures/missing-operation/queries/projectA/Query.graphql
@@ -1,0 +1,3 @@
+query A {
+  nameA
+}

--- a/packages/graphql-validate-fixtures/test/fixtures/missing-operation/queries/projectB/Query.graphql
+++ b/packages/graphql-validate-fixtures/test/fixtures/missing-operation/queries/projectB/Query.graphql
@@ -1,0 +1,3 @@
+query B {
+  nameB
+}

--- a/packages/graphql-validate-fixtures/test/fixtures/missing-schema/.graphqlconfig.yml
+++ b/packages/graphql-validate-fixtures/test/fixtures/missing-schema/.graphqlconfig.yml
@@ -1,0 +1,4 @@
+schemaPath: schema.json
+includes:
+  - schema.graphql
+  - queries/**/*.graphql

--- a/packages/graphql-validate-fixtures/test/fixtures/multi-project/.graphqlconfig.yml
+++ b/packages/graphql-validate-fixtures/test/fixtures/multi-project/.graphqlconfig.yml
@@ -1,0 +1,9 @@
+projects:
+  projectA:
+    schemaPath: projectA-schema.graphql
+    includes:
+      - queries/projectA/**/*.graphql
+  projectB:
+    schemaPath: projectB-schema.graphql
+    includes:
+      - queries/projectB/**/*.graphql

--- a/packages/graphql-validate-fixtures/test/fixtures/multi-project/fixtures/projectA/AQuery/fixture.json
+++ b/packages/graphql-validate-fixtures/test/fixtures/multi-project/fixtures/projectA/AQuery/fixture.json
@@ -1,0 +1,3 @@
+{
+  "nameA": "Chris"
+}

--- a/packages/graphql-validate-fixtures/test/fixtures/multi-project/fixtures/projectB/BQuery/fixture.json
+++ b/packages/graphql-validate-fixtures/test/fixtures/multi-project/fixtures/projectB/BQuery/fixture.json
@@ -1,0 +1,3 @@
+{
+  "nameB": "Chris"
+}

--- a/packages/graphql-validate-fixtures/test/fixtures/multi-project/projectA-schema.graphql
+++ b/packages/graphql-validate-fixtures/test/fixtures/multi-project/projectA-schema.graphql
@@ -1,0 +1,7 @@
+type Query {
+  nameA: String!
+}
+
+schema {
+  query: Query
+}

--- a/packages/graphql-validate-fixtures/test/fixtures/multi-project/projectB-schema.graphql
+++ b/packages/graphql-validate-fixtures/test/fixtures/multi-project/projectB-schema.graphql
@@ -1,0 +1,7 @@
+type Query {
+  nameB: String!
+}
+
+schema {
+  query: Query
+}

--- a/packages/graphql-validate-fixtures/test/fixtures/multi-project/queries/projectA/Query.graphql
+++ b/packages/graphql-validate-fixtures/test/fixtures/multi-project/queries/projectA/Query.graphql
@@ -1,0 +1,3 @@
+query A {
+  nameA
+}

--- a/packages/graphql-validate-fixtures/test/fixtures/multi-project/queries/projectB/Query.graphql
+++ b/packages/graphql-validate-fixtures/test/fixtures/multi-project/queries/projectB/Query.graphql
@@ -1,0 +1,3 @@
+query B {
+  nameB
+}

--- a/packages/graphql-validate-fixtures/test/index.test.ts
+++ b/packages/graphql-validate-fixtures/test/index.test.ts
@@ -10,6 +10,24 @@ describe('evaluateFixtures()', () => {
     expect(await evaluateFixturesForFixturePath('all-clear')).toMatchSnapshot();
   });
 
+  it('handles multi-project fixtures without errors', async () => {
+    expect(
+      await evaluateFixturesForFixturePath('multi-project'),
+    ).toMatchSnapshot();
+  });
+
+  it('handles ambiguous operation names in multi-project fixtures with errors', async () => {
+    expect(
+      await evaluateFixturesForFixturePath('ambiguous-operation'),
+    ).toMatchSnapshot();
+  });
+
+  it('handles missing operation names in multi-project fixtures with errors', async () => {
+    expect(
+      await evaluateFixturesForFixturePath('missing-operation'),
+    ).toMatchSnapshot();
+  });
+
   it('handles fixtures with errors', async () => {
     expect(
       await evaluateFixturesForFixturePath('fixture-errors'),
@@ -33,32 +51,17 @@ describe('evaluateFixtures()', () => {
       evaluateFixturesForFixturePath('malformed-query'),
     ).rejects.toMatchSnapshot();
   });
-
-  describe('schemaOnly', () => {
-    it('validates against the schema only', async () => {
-      expect(
-        await evaluateFixturesForFixturePath('fixture-errors', {
-          schemaOnly: true,
-        }),
-      ).toMatchSnapshot();
-    });
-
-    it('does not fail on malformed GraphQL documents', async () => {
-      expect(
-        await evaluateFixturesForFixturePath('malformed-query', {
-          schemaOnly: true,
-        }),
-      ).toMatchSnapshot();
-    });
-  });
 });
 
 async function evaluateFixturesForFixturePath(
   fixture: string,
-  options?: Options,
+  options?: Partial<Options>,
 ) {
   try {
-    const result = await evaluateFixtures(detailsForFixture(fixture), options);
+    const result = await evaluateFixtures(detailsForFixture(fixture), {
+      cwd: join(rootFixtureDirectory, fixture),
+      ...options,
+    });
     return stripFullFilePaths(result);
   } catch (error) {
     throw stripFullFilePaths(error);
@@ -66,16 +69,5 @@ async function evaluateFixturesForFixturePath(
 }
 
 function detailsForFixture(fixture: string) {
-  const fixtureDirectory = join(rootFixtureDirectory, fixture);
-  const schemaPath = join(fixtureDirectory, 'schema.json');
-  const fixturePaths = glob.sync(join(fixtureDirectory, 'fixtures/**/*.json'));
-  const operationPaths = glob.sync(
-    join(fixtureDirectory, 'queries/**/*.graphql'),
-  );
-
-  return {
-    schemaPath,
-    fixturePaths,
-    operationPaths,
-  };
+  return glob.sync(join(rootFixtureDirectory, fixture, 'fixtures/**/*.json'));
 }


### PR DESCRIPTION
Updates this tool to use `graphql-config` for resolving schemas. Fixtures are mapped to operation names by the name of the directory they live within (or by using the `@operation` pragma if the directory name is not suitable). The workspace configuration is loaded and all operations all included files per schema are compiled into AST, which allows us to connect between fixture and operation, and by extension fixture and schema.

The `schemaOnly` (`--schema-only`) flag has been removed as it is no longer purposeful since we need to compile operations into AST for mapping purposes regardless of whether the flag is set (and the flag's main purpose was to speed boost by not performing a compilation). This means a lot of related functions were also removed because they were no longe being referenced.

It is possible for two operations to share the same name across multiple schemas, which can result in a fixture having an ambiguous mapping to a schema. In a future version, a new `@project` pragma will be introduced to directly map a fixture to a schema. Currently if this scenario occurs an _Ambiguous operation name_ error is produced as a validation error.