### PR TITLE
refactoring graphql functions

### DIFF
--- a/packages/graphql-tool-utilities/README.md
+++ b/packages/graphql-tool-utilities/README.md
@@ -20,6 +20,6 @@ yarn add graphql-tool-utilities
 
 #### `compile(schema: GraphQLSchema, document: DocumentNode, options?: CompilerOptions): AST`
 
-Compiles the provided schema and document into an intermediary representation using https://github.com/apollographql/apollo-codegen/blob/master/src/compilation.js. This intermediate representation makes it easy to navigate through operations and their fields, without having to manually traverse the document and associate fields with the schema manually.
+Compiles the provided schema and document into an intermediary representation using https://github.com/apollographql/apollo-cli/blob/master/packages/apollo-codegen-core/src/compiler/legacyIR.ts. This intermediate representation makes it easy to navigate through operations and their fields, without having to manually traverse the document and associate fields with the schema manually.
 
-See the TypeScript type definition for a detailed description of the returned `AST` type (or see `LegacyCompilerContext` inside the `apollo-codegen-core` module).
+`AST` is our own improvement to the `LegacyCompilerContext` type definitions, but still fully backwards compatible with `LegacyCompilerContext`. See the TypeScript type definition for a detailed description of the returned `AST` type (or see [`LegacyCompilerContext`](https://github.com/apollographql/apollo-cli/blob/master/packages/apollo-codegen-core/src/compiler/legacyIR.ts) inside the [`apollo-codegen-core` module](https://github.com/apollographql/apollo-cli/tree/master/packages/apollo-codegen-core)).

--- a/packages/graphql-tool-utilities/augmentations.ts
+++ b/packages/graphql-tool-utilities/augmentations.ts
@@ -1,0 +1,16 @@
+import {GraphQLProjectConfig} from 'graphql-config/lib/GraphQLProjectConfig';
+
+declare module 'graphql-config/lib/GraphQLProjectConfig' {
+  interface GraphQLProjectConfig {
+    resolveProjectName(defaultName?: string): string;
+  }
+}
+
+function resolveProjectName(
+  this: GraphQLProjectConfig,
+  defaultName = 'GraphQL',
+) {
+  return this.projectName || defaultName;
+}
+
+GraphQLProjectConfig.prototype.resolveProjectName = resolveProjectName;

--- a/packages/graphql-tool-utilities/config.ts
+++ b/packages/graphql-tool-utilities/config.ts
@@ -1,0 +1,59 @@
+import {GraphQLConfig, GraphQLProjectConfig} from 'graphql-config';
+import {isAbsolute, resolve} from 'path';
+
+import './augmentations';
+
+export function getGraphQLProjects(config: GraphQLConfig) {
+  const projects = config.getProjects();
+
+  if (projects) {
+    // multi-project configuration, return an array of projects
+    return Object.values(projects);
+  }
+
+  const project = config.getProjectConfig();
+
+  if (project) {
+    // single project configuration, return an array of the single project
+    return [project];
+  }
+
+  // invalid project configuration
+  throw new Error(`No projects defined in '${config.configPath}'`);
+}
+
+export function getGraphQLSchemaPaths(config: GraphQLConfig) {
+  return getGraphQLProjects(config).reduce<string[]>(
+    (schemas, {schemaPath}) => {
+      return schemaPath
+        ? schemas.concat(getGraphQLFilePath(config, schemaPath))
+        : schemas;
+    },
+    [],
+  );
+}
+
+export function getGraphQLProjectForSchemaPath(
+  config: GraphQLConfig,
+  schemaPath: string,
+) {
+  const project =
+    Object.values(config.getProjects() || {})
+      .filter((project) => project.schemaPath === schemaPath)
+      .shift() || config.getProjectConfig();
+
+  if (!project || project.schemaPath !== schemaPath) {
+    throw new Error(
+      `No project defined in graphql config for schema '${schemaPath}'`,
+    );
+  }
+
+  return project;
+}
+
+export function getGraphQLFilePath(
+  config: GraphQLConfig | GraphQLProjectConfig,
+  filePath: string,
+) {
+  return isAbsolute(filePath) ? filePath : resolve(config.configDir, filePath);
+}

--- a/packages/graphql-tool-utilities/package.json
+++ b/packages/graphql-tool-utilities/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "@types/graphql": "^0.13.0",
     "apollo-codegen": "^0.20.0",
-    "core-js": "^2.4.1"
+    "core-js": "^2.4.1",
+    "graphql-config": "^2.0.0"
   }
 }


### PR DESCRIPTION
consolidating `graphql-config` functions from `graphql-typescript-definitions` into `graphql-tool-utilities`.  This will be in preparation for #21 to start consuming common `graphql-config` related functions.