### PR TITLE
Fixes non-unique List responses

### DIFF
--- a/packages/graphql-fixtures/src/fill.ts
+++ b/packages/graphql-fixtures/src/fill.ts
@@ -21,10 +21,13 @@ import {
 } from 'graphql-tool-utilities';
 import {randomFromArray, chooseNull} from './utilities';
 
-export type FieldDetails = (Field | InlineFragment) & {
+export interface FieldMetadata {
+  fieldIndex?: number;
   fieldName: string;
   responseName: string;
-};
+}
+
+export type FieldDetails = (Field | InlineFragment) & FieldMetadata;
 
 export interface ResolveDetails {
   type: GraphQLType;
@@ -198,8 +201,21 @@ function unwrapThunk<T>(value: Thunk<T>, details: ResolveDetails): T {
   return isResolver(value) ? value({...details, type: unwrappedType}) : value;
 }
 
-function withRandom<T>(keypath: FieldDetails[], func: () => T) {
-  faker.seed(seedFromKeypath(keypath.map(({responseName}) => responseName)));
+function keyPathElement(responseName: string, fieldIndex: number | undefined) {
+  return fieldIndex == null ? responseName : `${responseName}[${fieldIndex}]`;
+}
+
+// we need to set a seedOffset when filling fields that are indexed leafs in the
+// graph, for indexed objects in the graph their key path will use the parent
+// field index instead.
+function withRandom<T>(keypath: FieldDetails[], func: () => T, seedOffset = 0) {
+  faker.seed(
+    seedFromKeypath(
+      keypath.map(({fieldIndex, responseName}) =>
+        keyPathElement(responseName, fieldIndex),
+      ),
+    ) + seedOffset,
+  );
   const value = func();
   faker.seed(Math.random() * 10000);
   return value;
@@ -210,15 +226,19 @@ function createValue<T>(
   value: Thunk<T>,
   details: ResolveDetails,
 ) {
-  return withRandom(details.parentFields, () => {
-    if (partialValue === undefined) {
-      return isNonNullType(details.type) || !chooseNull()
-        ? unwrapThunk(value, details)
-        : null;
-    } else {
-      return unwrapThunk(partialValue, details);
-    }
-  });
+  return withRandom(
+    details.parentFields,
+    () => {
+      if (partialValue === undefined) {
+        return isNonNullType(details.type) || !chooseNull()
+          ? unwrapThunk(value, details)
+          : null;
+      } else {
+        return unwrapThunk(partialValue, details);
+      }
+    },
+    details.field.fieldIndex,
+  );
 }
 
 function fillForPrimitiveType(
@@ -238,7 +258,7 @@ function fillForPrimitiveType(
 
 function fillType(
   type: GraphQLType,
-  field: Field,
+  field: Field & FieldMetadata,
   partial: Thunk<any>,
   parent: GraphQLObjectType,
   parentFields: FieldDetails[],
@@ -262,14 +282,11 @@ function fillType(
       field,
       parentFields,
     });
-    return array
-      ? array.map((value: any) =>
+    return Array.isArray(array)
+      ? array.map((value: any, fieldIndex) =>
           fillType(
             unwrappedType.ofType,
-            {
-              ...field,
-              responseName: (field.responseName += parentFields.indexOf(field)),
-            },
+            {...field, fieldIndex},
             value,
             parent,
             parentFields,

--- a/packages/graphql-fixtures/src/fill.ts
+++ b/packages/graphql-fixtures/src/fill.ts
@@ -266,7 +266,10 @@ function fillType(
       ? array.map((value: any) =>
           fillType(
             unwrappedType.ofType,
-            field,
+            {
+              ...field,
+              responseName: (field.responseName += parentFields.indexOf(field)),
+            },
             value,
             parent,
             parentFields,

--- a/packages/graphql-fixtures/tests/fill.test.ts
+++ b/packages/graphql-fixtures/tests/fill.test.ts
@@ -195,12 +195,10 @@ describe('createFiller()', () => {
     it('uses the same value for a given keypath', () => {
       const document = createDocument(`
         query Details {
-          self { name, petPreference, birthday}
+          self { name, petPreference, birthday }
           sibling { name }
         }
       `);
-
-      console.log(fill(document));
 
       expect(fill(document)).toEqual(fill(document));
     });

--- a/packages/graphql-fixtures/tests/fill.test.ts
+++ b/packages/graphql-fixtures/tests/fill.test.ts
@@ -183,6 +183,7 @@ describe('createFiller()', () => {
         name: String!
         petPreference: PetPreference!
         birthday: Date!
+        parents: [Person!]!
       }
 
       type Query {
@@ -194,10 +195,12 @@ describe('createFiller()', () => {
     it('uses the same value for a given keypath', () => {
       const document = createDocument(`
         query Details {
-          self { name, petPreference, birthday }
+          self { name, petPreference, birthday}
           sibling { name }
         }
       `);
+
+      console.log(fill(document));
 
       expect(fill(document)).toEqual(fill(document));
     });
@@ -216,6 +219,20 @@ describe('createFiller()', () => {
       `);
 
       expect(fill(selfDocument).self).not.toEqual(fill(meDocument).me);
+    });
+
+    it('uses different values for a list of keypaths', () => {
+      const document = createDocument<{
+        self: {parents: {name: string}[]};
+      }>(`
+      query Details {
+        self { parents { name } }
+      }
+      `);
+
+      const data = fill(document, {self: {parents: () => [{}, {}]}});
+
+      expect(data.self.parents[0].name).not.toEqual(data.self.parents[1].name);
     });
   });
 


### PR DESCRIPTION
Items of a list type were returning the same data, which does not properly represent fake a real response. This PR looks for List types and adds the index of the field to the end of the `responseName` in order to force a different value for each field. I am open to a better ways to achieve this.

