### PR TITLE
adding support for vscode-jest

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+  "recommendations": [
+    "dbaeumer.vscode-eslint",
+    "esbenp.prettier-vscode",
+    "orta.vscode-jest"
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,22 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "name": "vscode-jest-tests",
+      "request": "launch",
+      "program": "${workspaceFolder}/node_modules/jest/bin/jest",
+      "args": [
+        "--runInBand",
+        "--config",
+        "${workspaceFolder}/config/jest/config.json"
+      ],
+      "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen"
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,6 +24,7 @@
     "packages/graphql-typed/*.js": true,
     "packages/graphql-typed/*.d.ts": true
   },
+  "jest.pathToConfig": "config/jest/config.json",
   "search.exclude": {
     "**/node_modules": true,
     "**/bower_components": true,


### PR DESCRIPTION
* updating `settings.json` so that `jest` uses our `config.json`
* adding `launch.json` config so that `vscode-jest` supports debugger integration
* ading `extensions.json` to recommend `vscode-jest` (as well as `eslint` and `prettier` extensions)