### PR TITLE
refactoring file watcher instrumentation

### DIFF
--- a/packages/graphql-typescript-definitions/test/__snapshots__/cli.test.ts.snap
+++ b/packages/graphql-typescript-definitions/test/__snapshots__/cli.test.ts.snap
@@ -71,16 +71,18 @@ Object {
   },
   "stderr": "",
   "stdout": "
- ERROR  Error parsing 'packages/graphql-typescript-definitions/test/fixtures/missing-schema/schema.json':
-
-ENOENT: no such file or directory, open 'packages/graphql-typescript-definitions/test/fixtures/missing-schema/schema.json'
-Error: Error parsing 'packages/graphql-typescript-definitions/test/fixtures/missing-schema/schema.json':
-
-ENOENT: no such file or directory, open 'packages/graphql-typescript-definitions/test/fixtures/missing-schema/schema.json'
+ ERROR  ENOENT: no such file or directory, open 'packages/graphql-typescript-definitions/test/fixtures/missing-schema/schema.json'
+Error: ENOENT: no such file or directory, open 'packages/graphql-typescript-definitions/test/fixtures/missing-schema/schema.json'
+    at Object.fs.openSync (fs.js)
+    at Object.fs.readFileSync (fs.js)
+    at Object.readSchema (node_modules/graphql-config/lib/utils.js)
+    at GraphQLProjectConfig.getSchema (node_modules/graphql-config/lib/GraphQLProjectConfig.js)
     at Builder.<anonymous> (packages/graphql-typescript-definitions/lib/index.js)
-    at Generator.throw (<anonymous>)
-    at rejected (packages/graphql-typescript-definitions/lib/index.js)
-    at <anonymous>
+    at Generator.next (<anonymous>)
+    at packages/graphql-typescript-definitions/lib/index.js
+    at new Promise (<anonymous>)
+    at __awaiter (packages/graphql-typescript-definitions/lib/index.js)
+    at Builder.generateSchemaTypes (packages/graphql-typescript-definitions/lib/index.js)
 
 ",
 }
@@ -95,6 +97,18 @@ Object {
 
  BUILT  packages/graphql-typescript-definitions/test/fixtures/missing-types/documents/Fragment.graphql → packages/graphql-typescript-definitions/test/fixtures/missing-types/documents/Fragment.graphql.d.ts
  BUILT  packages/graphql-typescript-definitions/test/fixtures/missing-types/documents/Query.graphql → packages/graphql-typescript-definitions/test/fixtures/missing-types/documents/Query.graphql.d.ts
+",
+}
+`;
+
+exports[`cli succeeds when schemaPath is set to a graphql file 1`] = `
+Object {
+  "error": null,
+  "stderr": "",
+  "stdout": "
+ BUILT  packages/graphql-typescript-definitions/test/fixtures/graphql-schema/schema.graphql → packages/graphql-typescript-definitions/test/fixtures/graphql-schema/schema.ts
+
+ BUILT  packages/graphql-typescript-definitions/test/fixtures/graphql-schema/documents/Query.graphql → packages/graphql-typescript-definitions/test/fixtures/graphql-schema/documents/Query.graphql.d.ts
 ",
 }
 `;

--- a/packages/graphql-typescript-definitions/test/__snapshots__/cli.test.ts.snap
+++ b/packages/graphql-typescript-definitions/test/__snapshots__/cli.test.ts.snap
@@ -22,12 +22,12 @@ Error: GraphQL operations must have a unique name. The operation FindPerson is d
     at Array.forEach (<anonymous>)
     at getDuplicateOperations.forEach (packages/graphql-typescript-definitions/lib/index.js)
     at Array.forEach (<anonymous>)
+    at Builder.generateDocumentTypes (packages/graphql-typescript-definitions/lib/index.js)
     at Builder.<anonymous> (packages/graphql-typescript-definitions/lib/index.js)
     at Generator.next (<anonymous>)
     at packages/graphql-typescript-definitions/lib/index.js
     at new Promise (<anonymous>)
     at __awaiter (packages/graphql-typescript-definitions/lib/index.js)
-    at Builder.generateDocumentTypes (packages/graphql-typescript-definitions/lib/index.js)
 
 ",
 }
@@ -55,7 +55,7 @@ GraphQLError: Syntax Error: Expected {, found Name \\"name\\"
     at parseDefinition (node_modules/graphql/language/parser.js)
     at parseDocument (node_modules/graphql/language/parser.js)
     at Object.parse (node_modules/graphql/language/parser.js)
-    at Builder.<anonymous> (packages/graphql-typescript-definitions/lib/index.js)
+    at Builder.updateDocumentForFile (packages/graphql-typescript-definitions/lib/index.js)
 
 ",
 }
@@ -77,12 +77,12 @@ Error: ENOENT: no such file or directory, open 'packages/graphql-typescript-defi
     at Object.fs.readFileSync (fs.js)
     at Object.readSchema (node_modules/graphql-config/lib/utils.js)
     at GraphQLProjectConfig.getSchema (node_modules/graphql-config/lib/GraphQLProjectConfig.js)
+    at Builder.generateSchemaTypes (packages/graphql-typescript-definitions/lib/index.js)
+    at schemaPaths.forEach (packages/graphql-typescript-definitions/lib/index.js)
+    at Array.forEach (<anonymous>)
     at Builder.<anonymous> (packages/graphql-typescript-definitions/lib/index.js)
     at Generator.next (<anonymous>)
     at packages/graphql-typescript-definitions/lib/index.js
-    at new Promise (<anonymous>)
-    at __awaiter (packages/graphql-typescript-definitions/lib/index.js)
-    at Builder.generateSchemaTypes (packages/graphql-typescript-definitions/lib/index.js)
 
 ",
 }

--- a/packages/graphql-typescript-definitions/test/cli.test.ts
+++ b/packages/graphql-typescript-definitions/test/cli.test.ts
@@ -19,6 +19,12 @@ describe('cli', () => {
     ).toMatchSnapshot();
   });
 
+  it('succeeds when schemaPath is set to a graphql file', async () => {
+    expect(
+      await execDetails(cliCommandForFixtureDirectory('graphql-schema')),
+    ).toMatchSnapshot();
+  });
+
   it('fails when there are syntax errors', async () => {
     expect(
       await execDetails(cliCommandForFixtureDirectory('malformed-query')),

--- a/packages/graphql-typescript-definitions/test/fixtures/graphql-schema/.graphqlconfig
+++ b/packages/graphql-typescript-definitions/test/fixtures/graphql-schema/.graphqlconfig
@@ -1,0 +1,7 @@
+{
+  "schemaPath": "schema.graphql",
+  "includes": ["documents/**/*.graphql"],
+  "extensions": {
+    "schemaTypesPath": "schema.ts"
+  }
+}

--- a/packages/graphql-typescript-definitions/test/fixtures/graphql-schema/documents/Query.graphql
+++ b/packages/graphql-typescript-definitions/test/fixtures/graphql-schema/documents/Query.graphql
@@ -1,0 +1,5 @@
+query FindPerson {
+  person {
+    id
+  }
+}

--- a/packages/graphql-typescript-definitions/test/fixtures/graphql-schema/schema.graphql
+++ b/packages/graphql-typescript-definitions/test/fixtures/graphql-schema/schema.graphql
@@ -1,0 +1,11 @@
+type Person {
+  id: ID!
+}
+
+type Query {
+  person: Person
+}
+
+schema {
+  query: Query
+}

--- a/packages/graphql-typescript-definitions/test/index.test.ts
+++ b/packages/graphql-typescript-definitions/test/index.test.ts
@@ -1,0 +1,25 @@
+import {resolve} from 'path';
+import {Builder} from '../src/index';
+
+const rootFixturePath = resolve(__dirname, 'fixtures');
+
+describe('Builder', () => {
+  it('only calls generateDocumentTypes() once on startup in watch mode', async () => {
+    const fixtureDirectory = resolve(rootFixturePath, 'all-clear');
+    const builder = new Builder({
+      addTypename: true,
+      cwd: fixtureDirectory,
+      schemaTypesPath: fixtureDirectory,
+    });
+    const fn = jest.fn();
+
+    try {
+      builder.on('start:docs', fn);
+
+      await builder.run({watch: true});
+    } finally {
+      builder.stop();
+    }
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
resolves #28 

Setting the `ignoreInitial` option when we setup `chokidar` watchers to prevent file `add` events from being emitted on startup which can cause duplicate calls to the `generateDocumentTypes` function.

watchers are now composed per-project and one additional watcher for all schema files. Watchers and globbing now use both `includes` and `excludes` when constructing file matchers. This should eliminate any issues where excluded files are being included from an `include` in another project. This also enables a much cleaner code path for processing file paths because we should always have the current project config for the file path in scope.

This will likely also resolve #31 