### PR TITLE
using graphql-config for all schema file handling

### DIFF
--- a/packages/graphql-typescript-definitions/README.md
+++ b/packages/graphql-typescript-definitions/README.md
@@ -197,7 +197,7 @@ Input types (enums, input objects, and custom scalars) are generated once, in a 
 ### CLI
 
 ```sh
-yarn run graphql-typescript-definitions 'src/**/*.graphql' --schema-path 'build/schema.json' --schema-types-path 'src/schema.ts'
+yarn run graphql-typescript-definitions --schema-path 'build/schema.json' --schema-types-path 'src/schema.ts'
 ```
 
 Optionally, you can pass the `--watch` flag in order to regenerate the TypeScript definition files on changes to the GraphQL files. You can also pass the `--add-typename` flag in order to always generate a `__typename` field for object types, and an `--enum-format` type which specifies the casing to use for enum types generated from the schema.

--- a/packages/graphql-typescript-definitions/test/__snapshots__/cli.test.ts.snap
+++ b/packages/graphql-typescript-definitions/test/__snapshots__/cli.test.ts.snap
@@ -22,12 +22,12 @@ Error: GraphQL operations must have a unique name. The operation FindPerson is d
     at Array.forEach (<anonymous>)
     at getDuplicateOperations.forEach (packages/graphql-typescript-definitions/lib/index.js)
     at Array.forEach (<anonymous>)
+    at Builder.checkForDuplicateOperations (packages/graphql-typescript-definitions/lib/index.js)
     at Builder.<anonymous> (packages/graphql-typescript-definitions/lib/index.js)
     at Generator.next (<anonymous>)
     at packages/graphql-typescript-definitions/lib/index.js
     at new Promise (<anonymous>)
     at __awaiter (packages/graphql-typescript-definitions/lib/index.js)
-    at Builder.generateDocumentTypes (packages/graphql-typescript-definitions/lib/index.js)
 
 ",
 }
@@ -55,7 +55,7 @@ GraphQLError: Syntax Error: Expected {, found Name \\"name\\"
     at parseDefinition (node_modules/graphql/language/parser.js)
     at parseDocument (node_modules/graphql/language/parser.js)
     at Object.parse (node_modules/graphql/language/parser.js)
-    at Builder.<anonymous> (packages/graphql-typescript-definitions/lib/index.js)
+    at Builder.setDocumentForFilePath (packages/graphql-typescript-definitions/lib/index.js)
 
 ",
 }
@@ -96,6 +96,18 @@ Object {
 
  BUILT  packages/graphql-typescript-definitions/test/fixtures/missing-types/documents/Fragment.graphql → packages/graphql-typescript-definitions/test/fixtures/missing-types/documents/Fragment.graphql.d.ts
  BUILT  packages/graphql-typescript-definitions/test/fixtures/missing-types/documents/Query.graphql → packages/graphql-typescript-definitions/test/fixtures/missing-types/documents/Query.graphql.d.ts
+",
+}
+`;
+
+exports[`cli succeeds when schemaPath is set to a graphql file 1`] = `
+Object {
+  "error": null,
+  "stderr": "",
+  "stdout": "
+ BUILT  packages/graphql-typescript-definitions/test/fixtures/graphql-schema/schema.graphql → packages/graphql-typescript-definitions/test/fixtures/graphql-schema/schema.ts
+
+ BUILT  packages/graphql-typescript-definitions/test/fixtures/graphql-schema/documents/Query.graphql → packages/graphql-typescript-definitions/test/fixtures/graphql-schema/documents/Query.graphql.d.ts
 ",
 }
 `;

--- a/packages/graphql-typescript-definitions/test/cli.test.ts
+++ b/packages/graphql-typescript-definitions/test/cli.test.ts
@@ -19,6 +19,12 @@ describe('cli', () => {
     ).toMatchSnapshot();
   });
 
+  it('succeeds when schemaPath is set to a graphql file', async () => {
+    expect(
+      await execDetails(cliCommandForFixtureDirectory('graphql-schema')),
+    ).toMatchSnapshot();
+  });
+
   it('fails when there are syntax errors', async () => {
     expect(
       await execDetails(cliCommandForFixtureDirectory('malformed-query')),

--- a/packages/graphql-typescript-definitions/test/fixtures/graphql-schema/.graphqlconfig
+++ b/packages/graphql-typescript-definitions/test/fixtures/graphql-schema/.graphqlconfig
@@ -1,0 +1,7 @@
+{
+  "schemaPath": "schema.graphql",
+  "includes": ["documents/**/*.graphql"],
+  "extensions": {
+    "schemaTypesPath": "schema.ts"
+  }
+}

--- a/packages/graphql-typescript-definitions/test/fixtures/graphql-schema/documents/Query.graphql
+++ b/packages/graphql-typescript-definitions/test/fixtures/graphql-schema/documents/Query.graphql
@@ -1,0 +1,5 @@
+query FindPerson {
+  person {
+    id
+  }
+}

--- a/packages/graphql-typescript-definitions/test/fixtures/graphql-schema/schema.graphql
+++ b/packages/graphql-typescript-definitions/test/fixtures/graphql-schema/schema.graphql
@@ -1,0 +1,11 @@
+type Person {
+  id: ID!
+}
+
+type Query {
+  person: Person
+}
+
+schema {
+  query: Query
+}

--- a/packages/graphql-typescript-definitions/test/index.test.ts
+++ b/packages/graphql-typescript-definitions/test/index.test.ts
@@ -1,0 +1,25 @@
+import {resolve} from 'path';
+import {Builder} from '../src/index';
+
+const rootFixturePath = resolve(__dirname, 'fixtures');
+
+describe('Builder', () => {
+  it('only calls generateDocumentTypes() once on startup in watch mode', async () => {
+    const fixtureDirectory = resolve(rootFixturePath, 'all-clear');
+    const builder = new Builder({
+      addTypename: true,
+      cwd: fixtureDirectory,
+      schemaTypesPath: fixtureDirectory,
+    });
+    const fn = jest.fn();
+
+    try {
+      builder.on('start:docs', fn);
+
+      await builder.run({watch: true});
+    } finally {
+      builder.stop();
+    }
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
This PR removes what was left of legacy graphql file reading in `graphql-typescript-definitions` to process changes to the graphql schema file. We now rely entirely on the `graphql-config` instance by using the `getSchema()` function. This resolves #32

The `chokidar` file watchers and the `glob` function now respect `excludes` defined in the `graphql-config` file. Each project now produces its own pair of `chokidar` watchers (one for schema and one for documents). Similarly, globbing now occurs on a per-project basis. This allows projects to specifically cover only the files they want linked to a schema. This resolves #31 

`chokidar` no longer generates events on startup. Setting the `ignoreInitial` option when we setup `chokidar` watchers prevents file add events from being emitted on startup which were causing duplicate calls to the `generateDocumentTypes` function. This resolves #28 

This will end up being the last piece of the `graphql-config` puzzle. This resolves #5 

replaces #30
blocked on #37 and #38 