### PR TITLE
adding augmentation to simplify project schemaPath resolution

### DIFF
--- a/packages/graphql-tool-utilities/augmentations.ts
+++ b/packages/graphql-tool-utilities/augmentations.ts
@@ -3,6 +3,7 @@ import {GraphQLProjectConfig} from 'graphql-config/lib/GraphQLProjectConfig';
 declare module 'graphql-config/lib/GraphQLProjectConfig' {
   interface GraphQLProjectConfig {
     resolveProjectName(defaultName?: string): string;
+    resolveSchemaPath(): string;
   }
 }
 
@@ -13,4 +14,21 @@ function resolveProjectName(
   return this.projectName || defaultName;
 }
 
+function resolveSchemaPath(this: GraphQLProjectConfig) {
+  // schemaPath is nullable in graphq-config even though it cannot actually be
+  // omitted. This function simplifies access ot the schemaPath without
+  // requiring a type guard.
+  if (!this.schemaPath) {
+    // this case should never happen with a properly formatted config file.
+    // graphql-config currently does not perform any validation so it's possible
+    // for a mal-formed schema to be loaded at runtime.
+    throw new Error(
+      `Missing GraphQL schemaPath for project '${this.resolveProjectName()}'`,
+    );
+  }
+
+  return this.schemaPath;
+}
+
 GraphQLProjectConfig.prototype.resolveProjectName = resolveProjectName;
+GraphQLProjectConfig.prototype.resolveSchemaPath = resolveSchemaPath;


### PR DESCRIPTION
`GraphQLProjectConfig.schemaPath` is [nullable](https://github.com/prisma/graphql-config/blob/master/src/GraphQLProjectConfig.ts#L92) because it's possible to [share a schema](https://github.com/prisma/graphql-config/blob/4c09eef3b97ebfbde6aa3710dfcfb1fe845f6d60/specification.md#default-configuration-properties) across multiple projects. Due to the typing used in `graphql-config` this results in the `schemaPath` having a nullable type. In practice, a project without a schema is not valid. In order to reduce boilerplate to guard against an invalid schema, a resolution function is added to the project to simplify _access or throw_ on the `schemaPath`.