### PR TITLE
adding export surface for graphql-tool-utilities

### DIFF
--- a/packages/graphql-tool-utilities/index.ts
+++ b/packages/graphql-tool-utilities/index.ts
@@ -1,0 +1,8 @@
+import './augmentations';
+
+export {
+  getGraphQLFilePath,
+  getGraphQLProjectForSchemaPath,
+  getGraphQLProjects,
+  getGraphQLSchemaPaths,
+} from './config';


### PR DESCRIPTION
This PR is exporting the `graphql-config` helper functions so that consumers of this utility do not have to reach into the `config` module.  This PR also adds the augmentations for any consumers.
