### PR TITLE
adding getGraphQLProjectIncludedFilePaths function

### DIFF
--- a/packages/graphql-tool-utilities/config.ts
+++ b/packages/graphql-tool-utilities/config.ts
@@ -1,5 +1,7 @@
+import glob from 'glob';
 import {GraphQLConfig, GraphQLProjectConfig} from 'graphql-config';
 import {isAbsolute, resolve} from 'path';
+import {promisify} from 'util';
 
 import './augmentations';
 
@@ -28,6 +30,20 @@ export function getGraphQLSchemaPaths(config: GraphQLConfig) {
       getGraphQLFilePath(config, project.resolveSchemaPath()),
     );
   }, []);
+}
+
+export async function getGraphQLProjectIncludedFilePaths(
+  projectConfig: GraphQLProjectConfig,
+) {
+  return (await Promise.all(
+    projectConfig.includes.map((include) =>
+      promisify(glob)(getGraphQLFilePath(projectConfig, include), {
+        ignore: projectConfig.excludes.map((exclude) =>
+          getGraphQLFilePath(projectConfig, exclude),
+        ),
+      }),
+    ),
+  )).flatMap((filePaths) => filePaths);
 }
 
 export function getGraphQLProjectForSchemaPath(

--- a/packages/graphql-tool-utilities/index.ts
+++ b/packages/graphql-tool-utilities/index.ts
@@ -3,6 +3,7 @@ import './augmentations';
 export {
   getGraphQLFilePath,
   getGraphQLProjectForSchemaPath,
+  getGraphQLProjectIncludedFilePaths,
   getGraphQLProjects,
   getGraphQLSchemaPaths,
 } from './config';

--- a/packages/graphql-validate-fixtures/src/index.ts
+++ b/packages/graphql-validate-fixtures/src/index.ts
@@ -1,11 +1,12 @@
 import {readFile, readJSON} from 'fs-extra';
 import {resolve} from 'path';
-import glob from 'glob';
 import {Source, parse, concatAST, GraphQLSchema} from 'graphql';
 import {getGraphQLConfig, GraphQLProjectConfig} from 'graphql-config';
-import {getGraphQLFilePath, getGraphQLProjects} from 'graphql-tool-utilities';
+import {
+  getGraphQLProjectIncludedFilePaths,
+  getGraphQLProjects,
+} from 'graphql-tool-utilities';
 import {compile} from 'graphql-tool-utilities/ast';
-import {promisify} from 'util';
 
 import {
   Fixture,
@@ -43,15 +44,9 @@ export async function evaluateFixtures(
 async function getOperationsForProject(
   projectConfig: GraphQLProjectConfig,
 ): Promise<GraphQLProjectAST> {
-  const operationPaths = (await Promise.all(
-    projectConfig.includes.map((include) =>
-      promisify(glob)(getGraphQLFilePath(projectConfig, include), {
-        ignore: projectConfig.excludes.map((exclude) =>
-          getGraphQLFilePath(projectConfig, exclude),
-        ),
-      }),
-    ),
-  )).flatMap((filePaths) => filePaths);
+  const operationPaths = await getGraphQLProjectIncludedFilePaths(
+    projectConfig,
+  );
 
   const operationSources = await Promise.all(
     operationPaths.map(loadOperationSource),


### PR DESCRIPTION
Adding new utility function to unify how to generate a list of all included file paths for a specific `GraphQLProjectConfig` instance. Refactoring usage in `graphql-validate-fixtures` to use this new function. #33 will handle the refactoring for `graphql-typescript-definitions`.