### PR TITLE
unifying error handling of missing schema files

### DIFF
--- a/packages/graphql-tool-utilities/augmentations.ts
+++ b/packages/graphql-tool-utilities/augmentations.ts
@@ -1,3 +1,4 @@
+import {existsSync} from 'fs';
 import {GraphQLProjectConfig} from 'graphql-config/lib/GraphQLProjectConfig';
 
 declare module 'graphql-config/lib/GraphQLProjectConfig' {
@@ -27,7 +28,25 @@ function resolveSchemaPath(this: GraphQLProjectConfig) {
     );
   }
 
-  return this.schemaPath;
+  // resolve fully qualified schemaPath
+  const schemaPath = this.resolveConfigPath(this.schemaPath);
+
+  if (!existsSync(schemaPath)) {
+    const forProject = this.projectName
+      ? ` for project '${this.projectName}'`
+      : '';
+    throw new Error(
+      [
+        `Schema not found${forProject}.`,
+        `Expected to find the schema at '${schemaPath}' but the path does not exist.`,
+        `Check '${
+          this.configPath
+        }' and verify that schemaPath is configured correctly${forProject}.`,
+      ].join(' '),
+    );
+  }
+
+  return schemaPath;
 }
 
 GraphQLProjectConfig.prototype.resolveProjectName = resolveProjectName;

--- a/packages/graphql-tool-utilities/config.ts
+++ b/packages/graphql-tool-utilities/config.ts
@@ -26,9 +26,7 @@ export function getGraphQLProjects(config: GraphQLConfig) {
 
 export function getGraphQLSchemaPaths(config: GraphQLConfig) {
   return getGraphQLProjects(config).reduce<string[]>((schemas, project) => {
-    return schemas.concat(
-      getGraphQLFilePath(config, project.resolveSchemaPath()),
-    );
+    return schemas.concat(project.resolveSchemaPath());
   }, []);
 }
 

--- a/packages/graphql-typescript-definitions/src/index.ts
+++ b/packages/graphql-typescript-definitions/src/index.ts
@@ -123,7 +123,14 @@ export class Builder extends EventEmitter {
 
   async run({watch: watchGlobs = false} = {}) {
     const globs = this.getGlobs();
-    const schemaPaths = this.getSchemaPaths();
+    let schemaPaths: string[];
+
+    try {
+      schemaPaths = getGraphQLSchemaPaths(this.config);
+    } catch (error) {
+      this.emit('error', error);
+      return;
+    }
 
     const update = async (filePath: string) => {
       try {
@@ -363,10 +370,6 @@ export class Builder extends EventEmitter {
         ),
       );
     }, []);
-  }
-
-  private getSchemaPaths() {
-    return getGraphQLSchemaPaths(this.config);
   }
 
   private removeDocumentForFile(filePath: string) {

--- a/packages/graphql-typescript-definitions/test/__snapshots__/cli.test.ts.snap
+++ b/packages/graphql-typescript-definitions/test/__snapshots__/cli.test.ts.snap
@@ -70,17 +70,18 @@ Object {
     "signal": null,
   },
   "stderr": "",
-  "stdout": "
- ERROR  Error parsing 'packages/graphql-typescript-definitions/test/fixtures/missing-schema/schema.json':
-
-ENOENT: no such file or directory, open 'packages/graphql-typescript-definitions/test/fixtures/missing-schema/schema.json'
-Error: Error parsing 'packages/graphql-typescript-definitions/test/fixtures/missing-schema/schema.json':
-
-ENOENT: no such file or directory, open 'packages/graphql-typescript-definitions/test/fixtures/missing-schema/schema.json'
+  "stdout": " ERROR  Schema not found. Expected to find the schema at 'packages/graphql-typescript-definitions/test/fixtures/missing-schema/schema.json' but the path does not exist. Check 'packages/graphql-typescript-definitions/test/fixtures/missing-schema/.graphqlconfig' and verify that schemaPath is configured correctly.
+Error: Schema not found. Expected to find the schema at 'packages/graphql-typescript-definitions/test/fixtures/missing-schema/schema.json' but the path does not exist. Check 'packages/graphql-typescript-definitions/test/fixtures/missing-schema/.graphqlconfig' and verify that schemaPath is configured correctly.
+    at GraphQLProjectConfig.resolveSchemaPath (packages/graphql-tool-utilities/augmentations.js)
+    at getGraphQLProjects.reduce (packages/graphql-tool-utilities/config.js)
+    at Array.reduce (<anonymous>)
+    at Object.getGraphQLSchemaPaths (packages/graphql-tool-utilities/config.js)
     at Builder.<anonymous> (packages/graphql-typescript-definitions/lib/index.js)
-    at Generator.throw (<anonymous>)
-    at rejected (packages/graphql-typescript-definitions/lib/index.js)
-    at <anonymous>
+    at Generator.next (<anonymous>)
+    at packages/graphql-typescript-definitions/lib/index.js
+    at new Promise (<anonymous>)
+    at __awaiter (packages/graphql-typescript-definitions/lib/index.js)
+    at Builder.run (packages/graphql-typescript-definitions/lib/index.js)
 
 ",
 }


### PR DESCRIPTION
Now that the tooling is relying completely on `graphql-config` for resolution of graphql entities, we are also at the mercy of `graphql-config` for error handling (which it performs less than stellar at). The `resolveSchemaPath` function should be the primary entrypoint for all consumers to resolve the `schemaPath` of a `GraphQLProjectConfig` instance, therefore we can additionally check the existence of the schema file and throw a more human readable error (instead of relying on node's readFile error, `ENOENT: ...`)

### 🎩 Notes

I went with `existsSync` to prevent requiring an additional `fs-extra` dependency and because it didn't force consumers to use async functions. Open to change suggestions.