### PR TITLE
Remove getGraphQLFilePath function

### DIFF
--- a/packages/graphql-tool-utilities/augmentations.ts
+++ b/packages/graphql-tool-utilities/augmentations.ts
@@ -3,9 +3,20 @@ import {GraphQLProjectConfig} from 'graphql-config/lib/GraphQLProjectConfig';
 
 declare module 'graphql-config/lib/GraphQLProjectConfig' {
   interface GraphQLProjectConfig {
+    resolvePathRelativeToConfig(relativePath: string): string;
     resolveProjectName(defaultName?: string): string;
     resolveSchemaPath(): string;
   }
+}
+
+// temporary augmentation until `graphql-config` supports this new function
+// see: https://github.com/prisma/graphql-config/pull/113
+function resolvePathRelativeToConfig(
+  this: GraphQLProjectConfig,
+  relativePath: string,
+) {
+  // this is just an alias to resolveConfigPath with a more meaningful name
+  return this.resolveConfigPath(relativePath);
 }
 
 function resolveProjectName(
@@ -49,5 +60,6 @@ function resolveSchemaPath(this: GraphQLProjectConfig) {
   return schemaPath;
 }
 
+GraphQLProjectConfig.prototype.resolvePathRelativeToConfig = resolvePathRelativeToConfig;
 GraphQLProjectConfig.prototype.resolveProjectName = resolveProjectName;
 GraphQLProjectConfig.prototype.resolveSchemaPath = resolveSchemaPath;

--- a/packages/graphql-tool-utilities/config.ts
+++ b/packages/graphql-tool-utilities/config.ts
@@ -1,6 +1,5 @@
 import glob from 'glob';
 import {GraphQLConfig, GraphQLProjectConfig} from 'graphql-config';
-import {isAbsolute, resolve} from 'path';
 import {promisify} from 'util';
 
 import './augmentations';
@@ -35,9 +34,9 @@ export async function getGraphQLProjectIncludedFilePaths(
 ) {
   return (await Promise.all(
     projectConfig.includes.map((include) =>
-      promisify(glob)(getGraphQLFilePath(projectConfig, include), {
+      promisify(glob)(projectConfig.resolvePathRelativeToConfig(include), {
         ignore: projectConfig.excludes.map((exclude) =>
-          getGraphQLFilePath(projectConfig, exclude),
+          projectConfig.resolvePathRelativeToConfig(exclude),
         ),
       }),
     ),
@@ -60,11 +59,4 @@ export function getGraphQLProjectForSchemaPath(
   }
 
   return project;
-}
-
-export function getGraphQLFilePath(
-  config: GraphQLConfig | GraphQLProjectConfig,
-  filePath: string,
-) {
-  return isAbsolute(filePath) ? filePath : resolve(config.configDir, filePath);
 }

--- a/packages/graphql-tool-utilities/index.ts
+++ b/packages/graphql-tool-utilities/index.ts
@@ -1,7 +1,6 @@
 import './augmentations';
 
 export {
-  getGraphQLFilePath,
   getGraphQLProjectForSchemaPath,
   getGraphQLProjectIncludedFilePaths,
   getGraphQLProjects,

--- a/packages/graphql-typescript-definitions/src/index.ts
+++ b/packages/graphql-typescript-definitions/src/index.ts
@@ -10,7 +10,7 @@ import {
   concatAST,
 } from 'graphql';
 import chalk from 'chalk';
-import {dirname, resolve} from 'path';
+import {dirname, join, resolve} from 'path';
 import {readJSON, readFile, writeFile, mkdirp} from 'fs-extra';
 import {watch} from 'chokidar';
 import * as glob from 'glob';
@@ -20,7 +20,6 @@ import {
   GraphQLConfig,
 } from 'graphql-config';
 import {
-  getGraphQLFilePath,
   getGraphQLProjectForSchemaPath,
   getGraphQLProjects,
   getGraphQLSchemaPaths,
@@ -366,7 +365,7 @@ export class Builder extends EventEmitter {
     return this.getProjects().reduce<string[]>((globs, project) => {
       return globs.concat(
         project.includes.map((filePath) =>
-          getGraphQLFilePath(this.config, filePath),
+          project.resolvePathRelativeToConfig(filePath),
         ),
       );
     }, []);
@@ -387,12 +386,13 @@ export class Builder extends EventEmitter {
 
 function getSchemaTypesPath(project: GraphQLProjectConfig, options: Options) {
   if (typeof project.extensions.schemaTypesPath === 'string') {
-    return getGraphQLFilePath(project, project.extensions.schemaTypesPath);
+    return project.resolvePathRelativeToConfig(
+      project.extensions.schemaTypesPath,
+    );
   }
 
-  return getGraphQLFilePath(
-    project,
-    resolve(
+  return project.resolvePathRelativeToConfig(
+    join(
       options.schemaTypesPath,
       `${project.projectName ? `${project.projectName}-` : ''}types.ts`,
     ),


### PR DESCRIPTION
This function was added to simplify fully qualified resolution of paths relative to the `graphql-config` file. `GraphQLProjectConfig` already exposes this functionality wtih `resolveConfigPath`. This PR is refactoring usages of `getGraphQLFilePath` with `resolveConfigPath`.

this will conflict slightly with #37 and can be resolved by taking the change in #37