### PR TITLE
fixing glob import for wider typescript configuration support

### DIFF
--- a/packages/graphql-tool-utilities/config.ts
+++ b/packages/graphql-tool-utilities/config.ts
@@ -1,8 +1,11 @@
-import glob from 'glob';
 import {GraphQLConfig, GraphQLProjectConfig} from 'graphql-config';
 import {promisify} from 'util';
 
 import './augmentations';
+
+// we need to use an import/require here because it does not force consumers to
+// enable esModuleInterop in tsconfig.json
+import glob = require('glob');
 
 export function getGraphQLProjects(config: GraphQLConfig) {
   const projects = config.getProjects();


### PR DESCRIPTION
the previous `glob` import was taking advantage of `esModuleInterop` which may not be available in consumers' TypeScript configuration. By using an `import = require` we can avoid imposing this requirement.