### PR TITLE
fixing graphql version graphql-typed 

### DIFF
--- a/packages/graphql-typed/package.json
+++ b/packages/graphql-typed/package.json
@@ -23,7 +23,7 @@
   },
   "peerDependencies": {
     "@types/graphql": "^0.13.0",
-    "graphql": "^0.13.2"
+    "graphql": "0.13.2"
   },
   "devDependencies": {
     "typescript": "^2.8.3"


### PR DESCRIPTION
updating to a specific version (`0.13.2`) to be consistent with other packages. We were already pulling in `0.13.2` but now consumers of this package will not possibly duplicate `graphql`.