### PR TITLE
reducing yarn engine requirement to satisfy shipit

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "engines": {
     "node": ">=v8.9.4",
-    "yarn": ">=1.10.0"
+    "yarn": ">=1.9.4"
   },
   "author": "Shopify Inc.",
   "license": "MIT",


### PR DESCRIPTION
shipit won't support yarn 1.10.1 yet, so we'll reduce the `engine` requirements for the time being.