### PR TITLE
adding .npmignore file to graphql-typed

### DIFF
--- a/packages/graphql-typed/.npmignore
+++ b/packages/graphql-typed/.npmignore
@@ -1,0 +1,1 @@
+index.ts


### PR DESCRIPTION
this will prevent the `index.ts` from being published to npm.