### PR TITLE
fixing incorrect graphql-typed peer dependency version

### DIFF
--- a/packages/graphql-fixtures/package.json
+++ b/packages/graphql-fixtures/package.json
@@ -29,6 +29,6 @@
     "graphql-tool-utilities": "^0.9.0"
   },
   "peerDependencies": {
-    "graphql-typed": "^0.1.2"
+    "graphql-typed": "^0.2.0"
   }
 }

--- a/packages/graphql-typescript-definitions/package.json
+++ b/packages/graphql-typescript-definitions/package.json
@@ -44,6 +44,6 @@
     "graphql-tool-utilities": "^0.9.0"
   },
   "peerDependencies": {
-    "graphql-typed": "^0.1.2"
+    "graphql-typed": "^0.2.0"
   }
 }


### PR DESCRIPTION
`graphql-typed` received [a version bump](https://github.com/Shopify/graphql-tools-web/commit/3d22e2c2f20c5c2e8d149fd6b77053e1463dd70f#diff-1e5458edf14329426cb89d760ebda6f9R3), but no corresponding bump was made to the `peerDependency` versions in related packages.