### PR TITLE
upgrading core-js to 2.5.7

### DIFF
--- a/packages/graphql-tool-utilities/package.json
+++ b/packages/graphql-tool-utilities/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@types/graphql": "^0.13.0",
     "apollo-codegen-core": "0.28.1",
-    "core-js": "^2.4.1",
+    "core-js": "^2.5.7",
     "graphql": "0.13.2",
     "graphql-config": "2.1.1"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1595,15 +1595,10 @@ core-js@^1.0.0:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
   integrity sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=
 
-core-js@^2.0.0, core-js@^2.4.1, core-js@^2.5.0, core-js@^2.5.3:
-  version "2.5.5"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.5.tgz#b14dde936c640c0579a6b50cabcc132dd6127e3b"
-  integrity sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs=
-
-core-js@^2.4.0:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.4.1.tgz#4de911e667b0eae9124e34254b53aea6fc618d3e"
-  integrity sha1-TekR5mew6ukSTjQlS1OupvxhjT4=
+core-js@^2.0.0, core-js@^2.4.0, core-js@^2.5.0, core-js@^2.5.3, core-js@^2.5.7:
+  version "2.5.7"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
+  integrity sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==
 
 core-util-is@~1.0.0:
   version "1.0.2"


### PR DESCRIPTION
`graphql-tool-utilities` requires at least `core-js@2.5.0` to [provide `flatMap`](https://github.com/zloirock/core-js/blob/v2.5.7/CHANGELOG.md#250---20170805).

This PR also consolidates all `core-js@^2.0.0` versions to `2.5.7`