### PR TITLE
Generate "empty Other" type for unions and interfaces

### DIFF
--- a/packages/graphql-typescript-definitions/src/print/document/language.ts
+++ b/packages/graphql-typescript-definitions/src/print/document/language.ts
@@ -110,6 +110,10 @@ function tsTypeForObjectField(
   context: OperationContext,
 ) {
   const {inlineFragments = []} = field;
+  const possibleTypes =
+    isInterfaceType(graphQLType) || isUnionType(graphQLType)
+      ? context.ast.schema.getPossibleTypes(graphQLType)
+      : [];
 
   if (inlineFragments.length) {
     const fragmentTypes = [...inlineFragments].map((inlineFragment) =>
@@ -128,38 +132,64 @@ function tsTypeForObjectField(
         [],
       ),
     );
-    const missingPossibleTypes =
-      isInterfaceType(graphQLType) || isUnionType(graphQLType)
-        ? context.ast.schema
-            .getPossibleTypes(graphQLType)
-            .filter((possibleType) => {
-              return !typesCoveredByInlineFragments.has(possibleType);
-            })
-        : [];
 
-    let otherType: t.TSType | null = null;
+    const missingPossibleTypes = possibleTypes.filter((possibleType) => {
+      return !typesCoveredByInlineFragments.has(possibleType);
+    });
 
-    if (missingPossibleTypes.length > 0) {
-      const otherStack = stack.fragment();
-      const otherTypeInterface = t.tsInterfaceDeclaration(
-        t.identifier(otherStack.name),
-        null,
-        null,
-        tsInterfaceBodyForObjectField(
-          field,
-          missingPossibleTypes,
-          otherStack,
-          context,
-          context.options.partial,
-        ),
-      );
-
-      otherType = context.export(otherTypeInterface);
-    }
-
-    return t.tsUnionType(
-      otherType ? [...fragmentTypes, otherType] : fragmentTypes,
+    const otherStack = stack.fragment();
+    const otherTypeInterface = t.tsInterfaceDeclaration(
+      t.identifier(otherStack.name),
+      null,
+      null,
+      tsInterfaceBodyForObjectField(
+        field,
+        missingPossibleTypes,
+        otherStack,
+        context,
+        context.options.partial,
+      ),
     );
+
+    const otherType = context.export(otherTypeInterface);
+
+    return t.tsUnionType([...fragmentTypes, otherType]);
+  } else if (possibleTypes.length === 1) {
+    // When we have an interface or union type, but no inline fragments, it
+    // means that there is only one conforming type for the union/ interface.
+    // Here, we construct a "nothing" type that stands in for future additions
+    // to the membership of the union/ interface.
+    const otherStack = stack.fragment();
+    const otherTypeInterface = t.tsInterfaceDeclaration(
+      t.identifier(otherStack.name),
+      null,
+      null,
+      tsInterfaceBodyForObjectField(
+        {...field, fields: []},
+        [],
+        otherStack,
+        context,
+        context.options.partial,
+      ),
+    );
+
+    const interfaceStack = stack.fragment(possibleTypes[0]);
+    const interfaceDeclaration = t.tsInterfaceDeclaration(
+      t.identifier(interfaceStack.name),
+      null,
+      null,
+      tsInterfaceBodyForObjectField(
+        field,
+        graphQLType,
+        interfaceStack,
+        context,
+      ),
+    );
+
+    return t.tsUnionType([
+      context.export(interfaceDeclaration),
+      context.export(otherTypeInterface),
+    ]);
   }
 
   const interfaceDeclaration = t.tsInterfaceDeclaration(
@@ -201,10 +231,15 @@ function tsPropertyForField(
       [],
     );
 
-    const typename =
-      allPossibleTypes.length > 1
-        ? t.tsUnionType(allPossibleTypes.map(tsTypenameForGraphQLType))
-        : tsTypenameForGraphQLType(allPossibleTypes[0]);
+    let typename: t.TSType;
+
+    if (allPossibleTypes.length === 0) {
+      typename = t.tsNeverKeyword();
+    } else if (allPossibleTypes.length > 1) {
+      typename = t.tsUnionType(allPossibleTypes.map(tsTypenameForGraphQLType));
+    } else {
+      typename = tsTypenameForGraphQLType(allPossibleTypes[0]);
+    }
 
     const typenameProperty = t.tsPropertySignature(
       t.identifier(field.responseName),

--- a/packages/graphql-typescript-definitions/src/print/document/language.ts
+++ b/packages/graphql-typescript-definitions/src/print/document/language.ts
@@ -165,7 +165,7 @@ function tsTypeForObjectField(
       null,
       null,
       tsInterfaceBodyForObjectField(
-        {...field, fields: []},
+        {fields: []},
         [],
         otherStack,
         context,


### PR DESCRIPTION
Currently, if a union or interface has all its possible types accounted for, or if there is only a single implementing type, we do not generate the "Other" type for a union or interface. That is, given the following schema:

```graphql
interface Animal {
  legs: Int!
}

type Dog implements Animal {
  legs: Int!
}

type Person {
  name: String!
  pets: [Animal]!
}

union Creature = Person | Dog

type Query {
  creature: Creature
}
```

and this query:

```graphql
query MyQuery {
  creature {
    ... on Dog { legs }
    ... on Person {
      pets { ... on Dog { legs } }
    }
  }
}
```

We generate the following types:

```ts
namespace MyQueryData {
  type CreatureDog = {} // for creature as Dog
  type CreaturePerson = {} // for creature as Person
  type CreaturePersonPets = {} // for creature.pets
}
```

This PR changes this type generation to always create an "Other" for each of these, even if there are no other types available. This is important because, if an implementing type is added to an interface/ a new type added to a union, the user of these types has no way to protect themselves; they have no alternative type they can reference that will continue to be present after the schema change. For example, adding the following to the schema:

```graphql
type Cat implements Animal {
  legs: Int!
  lives: Int!
}

union Creature = Person | Dog | Cat
```

Would update the types to the following:

```ts
namespace MyQueryData {
  type CreatureDog = {}
  type CreaturePerson = {}
  type CreatureOther = {} // NEW
  type CreaturePersonPetsDog = {} // CHANGED: now needs to be refined to the implementing type
  type CreaturePersonPetsOther = {} // NEW
}
```

This PR simply makes it so that the types above are generated always, even if they may not technically be necessary. It also uses a `__typename: never` for them if typename is added, so that it continues to accurately reflect what data can come back.

cc/ @patsissons does this seem insane?
cc/ @loic-d since this would have helped what you ran into.