### PR TITLE
Add some helper types

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -33,5 +33,6 @@
     "packages/graphql-tool-utilities/*.js": true,
     "packages/graphql-typed/*.js": true,
     "packages/**/*.d.ts": true
-  }
+  },
+  "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/packages/graphql-typed/index.ts
+++ b/packages/graphql-typed/index.ts
@@ -6,8 +6,35 @@ import {
 } from 'graphql';
 
 // @ts-ignore
+export interface GraphQLOperation<
+  Data = {},
+  Variables = {},
+  DeepPartial = {}
+> {}
+
 export interface DocumentNode<Data = {}, Variables = {}, DeepPartial = {}>
-  extends BaseDocumentNode {}
+  extends BaseDocumentNode,
+    GraphQLOperation<Data, Variables, DeepPartial> {}
+
+export type GraphQLData<T> = T extends GraphQLOperation<infer Data, any, any>
+  ? Data
+  : never;
+
+export type GraphQLVariables<T> = T extends GraphQLOperation<
+  any,
+  infer Variables,
+  any
+>
+  ? Variables
+  : never;
+
+export type GraphQLDeepPartial<T> = T extends GraphQLOperation<
+  any,
+  any,
+  infer DeepPartial
+>
+  ? DeepPartial
+  : never;
 
 export const parse: <Data = {}, Variables = {}, DeepPartial = {}>(
   source: string | Source,

--- a/packages/graphql-typed/index.ts
+++ b/packages/graphql-typed/index.ts
@@ -7,8 +7,11 @@ import {
 
 // @ts-ignore
 export interface GraphQLOperation<
+  // @ts-ignore
   Data = {},
+  // @ts-ignore
   Variables = {},
+  // @ts-ignore
   DeepPartial = {}
 > {}
 


### PR DESCRIPTION
Adds a few helper types that will be used to make it possible to write functions that take either a regular document node or another object that extends `GraphQLOperation` (like the async query components from `@shopify/react-graphql`)