### PR TITLE
Allow for exporting multiple operations and fragments from the same file

### DIFF
--- a/packages/graphql-typescript-definitions/src/index.ts
+++ b/packages/graphql-typescript-definitions/src/index.ts
@@ -59,7 +59,7 @@ export interface SchemaBuild {
 export interface DocumentBuild {
   documentPath: string;
   definitionPath: string;
-  operation?: Operation;
+  operations: Operation[];
   fragments: Fragment[];
 }
 
@@ -345,7 +345,7 @@ export class Builder extends EventEmitter {
     this.emit('build:docs', {
       documentPath: file.path,
       definitionPath,
-      operation: file.operation,
+      operations: file.operations,
       fragments: file.fragments,
     });
   }
@@ -434,7 +434,7 @@ function getSchemaTypesPath(
 
 interface File {
   path: string;
-  operation?: Operation;
+  operations: Operation[];
   fragments: Fragment[];
 }
 
@@ -451,7 +451,7 @@ function groupOperationsAndFragmentsByFile({operations, fragments}: AST) {
       if (!file) {
         file = {
           path: item.filePath,
-          operation: undefined,
+          operations: [],
           fragments: [],
         };
 
@@ -459,7 +459,7 @@ function groupOperationsAndFragmentsByFile({operations, fragments}: AST) {
       }
 
       if (isOperation(item)) {
-        file.operation = item;
+        file.operations.push(item);
       } else {
         file.fragments.push(item);
       }

--- a/packages/graphql-typescript-definitions/src/print/document/index.ts
+++ b/packages/graphql-typescript-definitions/src/print/document/index.ts
@@ -17,159 +17,183 @@ const generate = require('@babel/generator').default;
 
 export interface File {
   path: string;
-  operation?: Operation;
+  operations: Operation[];
   fragments: Fragment[];
 }
 
 export {Options};
 
 export function printDocument(
-  {path, operation, fragments}: File,
+  {path, operations, fragments}: File,
   ast: AST,
   options: Options,
 ) {
   const file = new FileContext(path, options);
 
-  if (operation == null) {
-    const fileBody = fragments.reduce<t.Statement[]>((statements, fragment) => {
-      const context = new OperationContext(fragment, ast, options, file);
-      const body = tsInterfaceBodyForObjectField(
-        fragment,
-        fragment.typeCondition,
-        new ObjectStack(fragment.typeCondition),
-        context,
-      );
+  const fileBody: t.Statement[] = [];
 
-      const {namespace} = context;
-
-      return [
-        ...statements,
-        ...(namespace ? [t.exportNamedDeclaration(namespace, [])] : []),
-        t.exportNamedDeclaration(
-          t.tsInterfaceDeclaration(
-            t.identifier(context.typeName),
-            null,
-            null,
-            body,
-          ),
-          [],
+  if (operations.length > 0) {
+    const baseDocumentNodeImport = t.importDeclaration(
+      [
+        t.importSpecifier(
+          t.identifier('BaseDocumentNode'),
+          t.identifier('DocumentNode'),
         ),
-      ];
-    }, []);
+      ],
+      t.stringLiteral('graphql'),
+    );
+    const documentNodeImport = t.importDeclaration(
+      [
+        t.importSpecifier(
+          t.identifier('DocumentNode'),
+          t.identifier('DocumentNode'),
+        ),
+      ],
+      t.stringLiteral('graphql-typed'),
+    );
 
-    const {schemaImports} = file;
+    const baseDocumentNodeDeclaratorIdentifier = t.identifier('document');
+    baseDocumentNodeDeclaratorIdentifier.typeAnnotation = t.tsTypeAnnotation(
+      t.tsTypeReference(t.identifier('BaseDocumentNode')),
+    );
 
-    if (schemaImports) {
-      fileBody.unshift(schemaImports);
+    const baseDocumentNodeDeclaration = t.variableDeclaration('const', [
+      t.variableDeclarator(baseDocumentNodeDeclaratorIdentifier),
+    ]);
+
+    baseDocumentNodeDeclaration.declare = true;
+
+    const documentNodeExport = t.exportDefaultDeclaration(
+      baseDocumentNodeDeclaratorIdentifier,
+    );
+
+    fileBody.push(
+      baseDocumentNodeImport,
+      documentNodeImport,
+      baseDocumentNodeDeclaration,
+      documentNodeExport,
+    );
+  }
+
+  for (const fragment of fragments) {
+    const context = new OperationContext(fragment, ast, options, file);
+    const body = tsInterfaceBodyForObjectField(
+      fragment,
+      fragment.typeCondition,
+      new ObjectStack(fragment.typeCondition),
+      context,
+    );
+
+    const {namespace} = context;
+
+    if (namespace) {
+      fileBody.push(t.exportNamedDeclaration(namespace, []));
     }
 
-    return generate(t.file(t.program(fileBody), [], [])).code;
+    fileBody.push(
+      t.exportNamedDeclaration(
+        t.tsInterfaceDeclaration(
+          t.identifier(context.typeName),
+          null,
+          null,
+          body,
+        ),
+        [],
+      ),
+    );
   }
 
-  const context = new OperationContext(operation, ast, options, file);
-  const partialContext = new OperationContext(
-    operation,
-    ast,
-    {...options, partial: true},
-    file,
-  );
+  for (const operation of operations) {
+    const context = new OperationContext(operation, ast, options, file);
+    const partialContext = new OperationContext(
+      operation,
+      ast,
+      {...options, partial: true},
+      file,
+    );
 
-  let rootType: GraphQLObjectType;
+    let rootType: GraphQLObjectType;
 
-  if (operation.operationType === OperationType.Query) {
-    rootType = ast.schema.getQueryType() as any;
-  } else if (operation.operationType === OperationType.Mutation) {
-    rootType = ast.schema.getMutationType() as any;
-  } else {
-    rootType = ast.schema.getSubscriptionType() as any;
+    if (operation.operationType === OperationType.Query) {
+      rootType = ast.schema.getQueryType() as any;
+    } else if (operation.operationType === OperationType.Mutation) {
+      rootType = ast.schema.getMutationType() as any;
+    } else {
+      rootType = ast.schema.getSubscriptionType() as any;
+    }
+
+    const variables =
+      operation.variables.filter(isTypedVariable).length > 0
+        ? context.export(variablesInterface(operation.variables, context))
+        : null;
+
+    const operationInterface = t.tsInterfaceDeclaration(
+      t.identifier(context.typeName),
+      null,
+      null,
+      tsInterfaceBodyForObjectField(
+        operation,
+        rootType,
+        new ObjectStack(rootType),
+        context,
+      ),
+    );
+
+    const operationPartialInterface = t.tsInterfaceDeclaration(
+      t.identifier(partialContext.typeName),
+      null,
+      null,
+      tsInterfaceBodyForObjectField(
+        operation,
+        rootType,
+        new ObjectStack(rootType),
+        partialContext,
+      ),
+    );
+
+    const {namespace} = context;
+    const {namespace: partialNamespace} = partialContext;
+
+    const documentNodeDeclaratorIdentifier = t.identifier(
+      operation.operationName,
+    );
+    documentNodeDeclaratorIdentifier.typeAnnotation = t.tsTypeAnnotation(
+      t.tsTypeReference(
+        t.identifier('DocumentNode'),
+        t.tsTypeParameterInstantiation([
+          t.tsTypeReference(t.identifier(context.typeName)),
+          variables || t.tsNeverKeyword(),
+          t.tsTypeReference(t.identifier(partialContext.typeName)),
+        ]),
+      ),
+    );
+
+    const documentNodeDeclaration = t.variableDeclaration('const', [
+      t.variableDeclarator(documentNodeDeclaratorIdentifier),
+    ]);
+
+    documentNodeDeclaration.declare = true;
+
+    if (partialNamespace) {
+      fileBody.push(t.exportNamedDeclaration(partialNamespace, []));
+    }
+
+    fileBody.push(t.exportNamedDeclaration(operationPartialInterface, []));
+
+    if (namespace) {
+      fileBody.push(t.exportNamedDeclaration(namespace, []));
+    }
+
+    fileBody.push(
+      t.exportNamedDeclaration(operationInterface, []),
+      t.exportNamedDeclaration(documentNodeDeclaration, []),
+    );
   }
-
-  const variables =
-    operation.variables.filter(isTypedVariable).length > 0
-      ? context.export(variablesInterface(operation.variables, context))
-      : null;
-
-  const operationInterface = t.tsInterfaceDeclaration(
-    t.identifier(context.typeName),
-    null,
-    null,
-    tsInterfaceBodyForObjectField(
-      operation,
-      rootType,
-      new ObjectStack(rootType),
-      context,
-    ),
-  );
-
-  const operationPartialInterface = t.tsInterfaceDeclaration(
-    t.identifier(partialContext.typeName),
-    null,
-    null,
-    tsInterfaceBodyForObjectField(
-      operation,
-      rootType,
-      new ObjectStack(rootType),
-      partialContext,
-    ),
-  );
 
   const {schemaImports} = file;
-  const {namespace} = context;
-  const {namespace: partialNamespace} = partialContext;
-
-  const documentNodeImport = t.importDeclaration(
-    [
-      t.importSpecifier(
-        t.identifier('DocumentNode'),
-        t.identifier('DocumentNode'),
-      ),
-    ],
-    t.stringLiteral('graphql-typed'),
-  );
-
-  const documentNodeDeclaratorIdentifier = t.identifier('document');
-  documentNodeDeclaratorIdentifier.typeAnnotation = t.tsTypeAnnotation(
-    t.tsTypeReference(
-      t.identifier('DocumentNode'),
-      t.tsTypeParameterInstantiation([
-        t.tsTypeReference(t.identifier(context.typeName)),
-        variables || t.tsNeverKeyword(),
-        t.tsTypeReference(t.identifier(partialContext.typeName)),
-      ]),
-    ),
-  );
-
-  const documentNodeDeclaration = t.variableDeclaration('const', [
-    t.variableDeclarator(documentNodeDeclaratorIdentifier),
-  ]);
-
-  documentNodeDeclaration.declare = true;
-
-  const documentNodeExport = t.exportDefaultDeclaration(
-    t.identifier('document'),
-  );
-
-  const fileBody: t.Statement[] = [documentNodeImport];
-
   if (schemaImports) {
-    fileBody.push(schemaImports);
+    fileBody.unshift(schemaImports);
   }
-
-  if (partialNamespace) {
-    fileBody.push(t.exportNamedDeclaration(partialNamespace, []));
-  }
-
-  fileBody.push(t.exportNamedDeclaration(operationPartialInterface, []));
-
-  if (namespace) {
-    fileBody.push(t.exportNamedDeclaration(namespace, []));
-  }
-
-  fileBody.push(
-    t.exportNamedDeclaration(operationInterface, []),
-    documentNodeDeclaration,
-    documentNodeExport,
-  );
 
   return generate(t.file(t.program(fileBody), [], [])).code;
 }

--- a/packages/graphql-typescript-definitions/src/print/document/index.ts
+++ b/packages/graphql-typescript-definitions/src/print/document/index.ts
@@ -33,15 +33,6 @@ export function printDocument(
   const fileBody: t.Statement[] = [];
 
   if (operations.length > 0) {
-    const baseDocumentNodeImport = t.importDeclaration(
-      [
-        t.importSpecifier(
-          t.identifier('BaseDocumentNode'),
-          t.identifier('DocumentNode'),
-        ),
-      ],
-      t.stringLiteral('graphql'),
-    );
     const documentNodeImport = t.importDeclaration(
       [
         t.importSpecifier(
@@ -52,27 +43,7 @@ export function printDocument(
       t.stringLiteral('graphql-typed'),
     );
 
-    const baseDocumentNodeDeclaratorIdentifier = t.identifier('document');
-    baseDocumentNodeDeclaratorIdentifier.typeAnnotation = t.tsTypeAnnotation(
-      t.tsTypeReference(t.identifier('BaseDocumentNode')),
-    );
-
-    const baseDocumentNodeDeclaration = t.variableDeclaration('const', [
-      t.variableDeclarator(baseDocumentNodeDeclaratorIdentifier),
-    ]);
-
-    baseDocumentNodeDeclaration.declare = true;
-
-    const documentNodeExport = t.exportDefaultDeclaration(
-      baseDocumentNodeDeclaratorIdentifier,
-    );
-
-    fileBody.push(
-      baseDocumentNodeImport,
-      documentNodeImport,
-      baseDocumentNodeDeclaration,
-      documentNodeExport,
-    );
+    fileBody.push(documentNodeImport);
   }
 
   for (const fragment of fragments) {
@@ -188,6 +159,42 @@ export function printDocument(
       t.exportNamedDeclaration(operationInterface, []),
       t.exportNamedDeclaration(documentNodeDeclaration, []),
     );
+
+    if (operations.length === 1) {
+      fileBody.push(
+        t.exportDefaultDeclaration(documentNodeDeclaratorIdentifier),
+      );
+    }
+  }
+
+  if (operations.length > 1) {
+    const baseDocumentNodeImport = t.importDeclaration(
+      [
+        t.importSpecifier(
+          t.identifier('BaseDocumentNode'),
+          t.identifier('DocumentNode'),
+        ),
+      ],
+      t.stringLiteral('graphql'),
+    );
+
+    const baseDocumentNodeDeclaratorIdentifier = t.identifier('document');
+    baseDocumentNodeDeclaratorIdentifier.typeAnnotation = t.tsTypeAnnotation(
+      t.tsTypeReference(t.identifier('BaseDocumentNode')),
+    );
+
+    const baseDocumentNodeDeclaration = t.variableDeclaration('const', [
+      t.variableDeclarator(baseDocumentNodeDeclaratorIdentifier),
+    ]);
+
+    baseDocumentNodeDeclaration.declare = true;
+
+    const baseDocumentNodeExport = t.exportDefaultDeclaration(
+      baseDocumentNodeDeclaratorIdentifier,
+    );
+
+    fileBody.unshift(baseDocumentNodeImport);
+    fileBody.push(baseDocumentNodeDeclaration, baseDocumentNodeExport);
   }
 
   const {schemaImports} = file;

--- a/packages/graphql-typescript-definitions/test/document.test.ts
+++ b/packages/graphql-typescript-definitions/test/document.test.ts
@@ -1983,9 +1983,9 @@ function print(
   const ast = compile(schema, concatAST([document, ...fragmentDocuments]));
   const file = {
     path: filename,
-    operation: Object.keys(ast.operations)
+    operations: Object.keys(ast.operations)
       .map((key) => ast.operations[key])
-      .filter((operation) => operation.filePath === filename)[0],
+      .filter((operation) => operation.filePath === filename),
     fragments: Object.keys(ast.fragments)
       .map((key) => ast.fragments[key])
       .filter((fragment) => fragment.filePath === filename),


### PR DESCRIPTION
`graphql-tag/loader` [allows for more than one exported operation type](https://github.com/apollographql/graphql-tag#support-for-multiple-operations), but `graphql-typescript-definitions` will only pick up the last operation defined. If an operation is defined, it will also ignore all fragments defined within the file.

This PR addresses that and allows for exporting multiple operations and fragments from the same file.

```ts
import { ProjectsQuery, ResultsQuery, ProjectFragmentData } from './Queries.gql';
```

~~Note that this is a **breaking** change: since the default export of a module is actually a composition of its definition and not necessarily a single operation, I've updated the type of the default export to `graphql`'s own untyped `DocumentNode` to better reflect this behavior. This means that existing code will break as typechecking will fail.~~

```ts
import ProjectsQuery from './Queries.gql';

// `ProjectsQuery` is an untyped graphql.DocumentNode that also contains
//  the definitions for `ResultsQuery`.
```

**(Implemented)** A backwards compatible but perhaps volatile change would be to keep the current behaviour when we detect that only one operation was defined within the file. This *might* break unexpectedly for existing files with multiple operations, but that would be indicative of an issue with the GraphQL definition file itself as only one operation was expected. Also, I don't know what happens when you feed a `DocumentNode` with more than one operation defined within to either Apollo or Relay, but the current behaviour might be deceptive in that regard.

**Disclaimer**: This PR fails to address the fact that `graphql-tag/loader` will also set every operation defined within the file as a property of the returned `DocumentNode`.

I'm putting this here as a heads up if you want to take a look at this change, as I will follow up with other contributions during the week, as well as take care of fixing/writing tests.