### PR TITLE
Accept a config option

### DIFF
--- a/packages/graphql-typescript-definitions/README.md
+++ b/packages/graphql-typescript-definitions/README.md
@@ -275,3 +275,4 @@ As with the CLI, you can pass options to customize the build and behavior:
 * `schemaPath`
 * `schemaTypesPath`
 * `customScalars`
+* `config` (custom `GraphQLConfig` instance)

--- a/packages/graphql-typescript-definitions/src/index.ts
+++ b/packages/graphql-typescript-definitions/src/index.ts
@@ -41,6 +41,7 @@ export {EnumFormat};
 export interface Options extends PrintDocumentOptions, PrintSchemaOptions {
   addTypename: boolean;
   schemaTypesPath: string;
+  config?: GraphQLConfig;
 }
 
 export interface BuilderOptions extends Options {
@@ -85,7 +86,9 @@ export class Builder extends EventEmitter {
     super();
     this.options = options;
 
-    this.config = getGraphQLConfig(cwd ? resolve(cwd) : undefined);
+    this.config = options.config
+      ? options.config
+      : getGraphQLConfig(cwd ? resolve(cwd) : undefined);
   }
 
   once(event: 'error', handler: (error: Error) => void): this;


### PR DESCRIPTION
I'm using the Builder API directly, but my project does not define a `.graphqlconfig` file, which means that I must create a temporary one just for the sake of running the type generation operation.

This change adds the possibility to provide a `config` option to the `Builder` options interface in order to provide your own custom `GraphQLConfig` instance.