### PR TITLE
fixing peer dependencies for graphql-typed and graphql-typescript-definitions

### DIFF
--- a/packages/graphql-fixtures/package.json
+++ b/packages/graphql-fixtures/package.json
@@ -32,6 +32,6 @@
     "graphql-tool-utilities": "^0.10.0"
   },
   "peerDependencies": {
-    "graphql-typed": "^0.2.0"
+    "graphql-typed": "^0.4.0"
   }
 }

--- a/packages/graphql-typescript-definitions/package.json
+++ b/packages/graphql-typescript-definitions/package.json
@@ -46,6 +46,6 @@
     "graphql-tool-utilities": "^0.10.0"
   },
   "peerDependencies": {
-    "graphql-typed": "^0.2.0"
+    "graphql-typed": "^0.4.0"
   }
 }


### PR DESCRIPTION
`peerDependencies` don't get auto-updated by lerna 🤕 