### PR TITLE
[DO_NOT_MERGE] splitting node exports of graphql-tool-utilities into new module

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 *.d.ts
+packages/graphql-tool-utilities/dist/**/*
 packages/graphql-typescript-definitions/test/fixtures/**/*.ts

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules
 packages/**/*.d.ts
 packages/graphql-typed/*.js
 packages/graphql-tool-utilities/*.js
+!packages/graphql-tool-utilities/dist/**/*
 packages/graphql-validate-fixtures/test/fixtures/**/schema.json
 packages/graphql-typescript-definitions/test/fixtures/**/schema.json
 packages/graphql-typescript-definitions/test/fixtures/**/types/*.ts

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,6 @@
 **/*.d.ts
 **/package.json
+packages/graphql-tool-utilities/dist/**/*
 packages/graphql-typescript-definitions/test/fixtures/malformed-query/**/*.graphql
 packages/graphql-typescript-definitions/test/fixtures/**/schema.ts
 packages/graphql-validate-fixtures/test/fixtures/malformed-query/**/*.graphql

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,8 +18,8 @@
     "**/.DS_Store": true,
     "**/node_modules": true,
     "**/lib": true,
-    "packages/graphql-tool-utilities/*.js": true,
-    "packages/graphql-tool-utilities/*.d.ts": true,
+    "packages/graphql-tool-utilities/(!dist)/*.js": true,
+    "packages/graphql-tool-utilities/(!dist)/*.d.ts": true,
     "packages/graphql-typed/*.js": true,
     "packages/graphql-typed/*.d.ts": true
   },
@@ -29,7 +29,7 @@
     "**/bower_components": true,
     "**/lib": true,
     "**/yarn.lock": true,
-    "packages/graphql-tool-utilities/*.js": true,
+    "packages/graphql-tool-utilities/(!dist)/*.js": true,
     "packages/graphql-typed/*.js": true,
     "packages/**/*.d.ts": true
   },

--- a/packages/graphql-tool-utilities/.npmignore
+++ b/packages/graphql-tool-utilities/.npmignore
@@ -1,3 +1,5 @@
+dist
+node.ts
 src
 test
 tsconfig.json

--- a/packages/graphql-tool-utilities/dist/node.d.ts
+++ b/packages/graphql-tool-utilities/dist/node.d.ts
@@ -1,0 +1,2 @@
+// @ts-ignore
+export * from './lib/node';

--- a/packages/graphql-tool-utilities/dist/node.js
+++ b/packages/graphql-tool-utilities/dist/node.js
@@ -1,0 +1,6 @@
+"use strict";
+function __export(m) {
+    for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
+}
+Object.defineProperty(exports, "__esModule", { value: true });
+__export(require("./lib/node"));

--- a/packages/graphql-tool-utilities/node.ts
+++ b/packages/graphql-tool-utilities/node.ts
@@ -1,0 +1,1 @@
+export * from './src/node';

--- a/packages/graphql-tool-utilities/package.json
+++ b/packages/graphql-tool-utilities/package.json
@@ -24,6 +24,7 @@
   ],
   "scripts": {
     "build": "tsc",
+    "postbuild": "cp dist/* .",
     "pretest": "yarn build",
     "prepublishOnly": "yarn build"
   },

--- a/packages/graphql-tool-utilities/src/index.ts
+++ b/packages/graphql-tool-utilities/src/index.ts
@@ -1,9 +1,2 @@
 export * from './ast';
-
-export {
-  getGraphQLProjectForSchemaPath,
-  getGraphQLProjectIncludedFilePaths,
-  getGraphQLProjects,
-  getGraphQLSchemaPaths,
-} from './config';
 export * from './utilities';

--- a/packages/graphql-tool-utilities/src/node.ts
+++ b/packages/graphql-tool-utilities/src/node.ts
@@ -1,0 +1,8 @@
+export * from './ast';
+export {
+  getGraphQLProjectForSchemaPath,
+  getGraphQLProjectIncludedFilePaths,
+  getGraphQLProjects,
+  getGraphQLSchemaPaths,
+} from './config';
+export * from './utilities';

--- a/packages/graphql-tool-utilities/tsconfig.json
+++ b/packages/graphql-tool-utilities/tsconfig.json
@@ -7,5 +7,11 @@
     "outDir": "lib"
   },
   "include": ["./**/*.ts"],
-  "exclude": ["./tests/**", "./lib/**", "node_modules/**"]
+  "exclude": [
+    "./node.ts",
+    "./tests/**",
+    "./lib/**",
+    "./dist/**",
+    "node_modules/**"
+  ]
 }

--- a/packages/graphql-typescript-definitions/src/index.ts
+++ b/packages/graphql-typescript-definitions/src/index.ts
@@ -27,7 +27,7 @@ import {
   isOperation,
   Operation,
   resolvePathRelativeToConfig,
-} from 'graphql-tool-utilities';
+} from 'graphql-tool-utilities/node';
 
 import {
   printDocument,

--- a/packages/graphql-validate-fixtures/src/index.ts
+++ b/packages/graphql-validate-fixtures/src/index.ts
@@ -6,7 +6,7 @@ import {
   compile,
   getGraphQLProjectIncludedFilePaths,
   getGraphQLProjects,
-} from 'graphql-tool-utilities';
+} from 'graphql-tool-utilities/node';
 
 import {
   Fixture,


### PR DESCRIPTION
In order to support usage of `graphql-tool-utilities` in a web context, we need to split the module into `node` and `default` exports. `node` will include everything in the `default` exports in addition to the `graphql-config` tooling, which requires a `node` context.

most imports will go on unaffected and can continue using `import {} from 'graphql-tool-utilities';`. However, for node specific usages, the import signature will change to `import {} from 'graphql-tool-utilities/node';`

### Reviewer Notes

Should we just create a new package for `graphql-config-utilities` instead of all these changes?