### PR TITLE
Fix Webpack transforms

### DIFF
--- a/packages/graphql-mini-transforms/src/document.ts
+++ b/packages/graphql-mini-transforms/src/document.ts
@@ -10,7 +10,7 @@ import {
   Location,
 } from 'graphql';
 
-const IMPORT_REGEX = /^#import\s+['"]([^'"]*)['"];?[\s\n]*/m;
+const IMPORT_REGEX = /^#import\s+['"]([^'"]*)['"];?[\s\n]*/gm;
 const DEFAULT_NAME = 'Operation';
 
 export function cleanDocument(document: DocumentNode) {

--- a/packages/graphql-mini-transforms/src/webpack.ts
+++ b/packages/graphql-mini-transforms/src/webpack.ts
@@ -6,7 +6,7 @@ import {cleanDocument, extractImports} from './document';
 
 export default async function graphQLLoader(
   this: loader.LoaderContext,
-  source: string,
+  source: string | Buffer,
 ) {
   this.cacheable();
 
@@ -27,11 +27,14 @@ export default async function graphQLLoader(
 }
 
 async function loadDocument(
-  rawSource: string,
+  rawSource: string | Buffer,
   resolveContext: string,
   loader: loader.LoaderContext,
 ): Promise<DocumentNode> {
-  const {imports, source} = extractImports(rawSource);
+  const normalizedSource =
+    typeof rawSource === 'string' ? rawSource : rawSource.toString();
+
+  const {imports, source} = extractImports(normalizedSource);
   const document = parse(source);
 
   if (imports.length === 0) {

--- a/packages/graphql-mini-transforms/tests/webpack.test.ts
+++ b/packages/graphql-mini-transforms/tests/webpack.test.ts
@@ -140,8 +140,8 @@ describe('graphql-mini-transforms/webpack', () => {
       const context = '/app/';
 
       const fragmentFiles = new Map([
-        ['./FooFragment.graphql', 'fragment FooFragment on Shop { id }'],
-        ['./BarFragment.graphql', 'fragment BarFragment on Shop { name }'],
+        ['/app/FooFragment.graphql', 'fragment FooFragment on Shop { id }'],
+        ['/app/BarFragment.graphql', 'fragment BarFragment on Shop { name }'],
       ]);
 
       const loader = createLoaderContext({
@@ -224,10 +224,11 @@ function createLoaderContext({
         file: string,
         withFile: (error: Error | null, result?: string | Buffer) => void,
       ) {
+        console.log(file);
         const read = readFile(file);
 
         if (typeof read === 'string') {
-          withFile(null, new Buffer(read));
+          withFile(null, Buffer.from(read, 'utf8'));
         } else {
           withFile(read);
         }

--- a/packages/graphql-mini-transforms/tests/webpack.test.ts
+++ b/packages/graphql-mini-transforms/tests/webpack.test.ts
@@ -146,7 +146,6 @@ describe('graphql-mini-transforms/webpack', () => {
 
       const loader = createLoaderContext({
         context,
-        // eslint-disable-next-line typescript/no-non-null-assertion
         readFile: (file) => fragmentFiles.get(file)!,
       });
 
@@ -224,7 +223,6 @@ function createLoaderContext({
         file: string,
         withFile: (error: Error | null, result?: string | Buffer) => void,
       ) {
-        console.log(file);
         const read = readFile(file);
 
         if (typeof read === 'string') {

--- a/packages/graphql-mini-transforms/tests/webpack.test.ts
+++ b/packages/graphql-mini-transforms/tests/webpack.test.ts
@@ -146,7 +146,8 @@ describe('graphql-mini-transforms/webpack', () => {
 
       const loader = createLoaderContext({
         context,
-        readFile: (file) => fragmentFiles.get(file),
+        // eslint-disable-next-line typescript/no-non-null-assertion
+        readFile: (file) => fragmentFiles.get(file)!,
       });
 
       const {

--- a/packages/graphql-mini-transforms/tests/webpack.test.ts
+++ b/packages/graphql-mini-transforms/tests/webpack.test.ts
@@ -136,6 +136,44 @@ describe('graphql-mini-transforms/webpack', () => {
       expect(body).toContain('fragment FooFragment on Shop');
     });
 
+    it('includes multiple imported sources', async () => {
+      const context = '/app/';
+
+      const fragmentFiles = new Map([
+        ['./FooFragment.graphql', 'fragment FooFragment on Shop { id }'],
+        ['./BarFragment.graphql', 'fragment BarFragment on Shop { name }'],
+      ]);
+
+      const loader = createLoaderContext({
+        context,
+        readFile: (file) => fragmentFiles.get(file),
+      });
+
+      const {
+        loc: {
+          source: {body},
+        },
+      } = await extractDocumentExport(
+        stripIndent`
+          #import './FooFragment.graphql';
+          #import './BarFragment.graphql';
+
+          query Shop {
+            shop {
+              ...FooFragment
+              ...BarFragment
+            }
+          }
+        `,
+        loader,
+      );
+
+      expect(body).toContain('...FooFragment');
+      expect(body).toContain('...BarFragment');
+      expect(body).toContain('fragment FooFragment on Shop');
+      expect(body).toContain('fragment BarFragment on Shop');
+    });
+
     it('excludes imported sources if they are not used', async () => {
       const context = '/app/';
       const loader = createLoaderContext({
@@ -183,12 +221,12 @@ function createLoaderContext({
     fs: {
       readFile(
         file: string,
-        withFile: (error: Error | null, result?: string) => void,
+        withFile: (error: Error | null, result?: string | Buffer) => void,
       ) {
         const read = readFile(file);
 
         if (typeof read === 'string') {
-          withFile(null, read);
+          withFile(null, new Buffer(read));
         } else {
           withFile(read);
         }


### PR DESCRIPTION
Fixes two issues with the Webpack transforms:

1. Now works correctly when `Buffer`s get involved
2. Now finds all imports, not just the first one (facepalm)