### PR TITLE
Allow custom scalars that alias built-in types

### DIFF
--- a/packages/graphql-typescript-definitions/CHANGELOG.md
+++ b/packages/graphql-typescript-definitions/CHANGELOG.md
@@ -3,7 +3,9 @@
 All notable consumer-facing changes are documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and from `v0.14.0`, this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+* Allow custom scalars that alias built-in types
 
 ## [0.18.0] - 2019-10-09
 

--- a/packages/graphql-typescript-definitions/README.md
+++ b/packages/graphql-typescript-definitions/README.md
@@ -245,6 +245,18 @@ import {SafeString} from 'my-custom-type-package';
 export type HtmlString = SafeString;
 ```
 
+You can also use built-in types by simply leaving off the `package` property:
+
+```sh
+yarn run graphql-typescript-definitions --schema-path 'build/schema.json' --schema-types-path 'src/schema' --custom-scalars '{"Seconds": {"name": "number"}}'
+```
+
+This will produce a simple type alias:
+
+```ts
+export type Seconds = number;
+```
+
 ### Node
 
 ```js

--- a/packages/graphql-typescript-definitions/src/print/schema/index.ts
+++ b/packages/graphql-typescript-definitions/src/print/schema/index.ts
@@ -19,7 +19,7 @@ const generate = require('@babel/generator').default;
 
 export interface ScalarDefinition {
   name: string;
-  package: string;
+  package?: string;
 }
 
 export interface Options {
@@ -69,7 +69,7 @@ export function generateSchemaTypes(
       const customScalarDefinition = customScalars[type.name];
       const scalarType = tsScalarForType(type, customScalarDefinition);
 
-      if (customScalarDefinition) {
+      if (customScalarDefinition && customScalarDefinition.package) {
         fileBody.unshift(
           t.importDeclaration(
             [
@@ -148,16 +148,19 @@ function tsScalarForType(
   type: GraphQLScalarType,
   customScalarDefinition?: ScalarDefinition,
 ) {
-  const alias = customScalarDefinition
-    ? t.tsTypeReference(
-        t.identifier(
-          makeCustomScalarImportNameSafe(
-            customScalarDefinition.name,
-            type.name,
-          ),
-        ),
-      )
-    : t.tsStringKeyword();
+  let alias;
+
+  if (customScalarDefinition && customScalarDefinition.package) {
+    alias = t.tsTypeReference(
+      t.identifier(
+        makeCustomScalarImportNameSafe(customScalarDefinition.name, type.name),
+      ),
+    );
+  } else if (customScalarDefinition) {
+    alias = t.tsTypeReference(t.identifier(customScalarDefinition.name));
+  } else {
+    alias = t.tsStringKeyword();
+  }
 
   return t.tsTypeAliasDeclaration(t.identifier(type.name), null, alias);
 }

--- a/packages/graphql-typescript-definitions/test/schema.test.ts
+++ b/packages/graphql-typescript-definitions/test/schema.test.ts
@@ -159,6 +159,26 @@ describe('printSchema()', () => {
     `);
   });
 
+  it('prints a custom scalar without a package import', () => {
+    const schema = buildSchema(`
+      scalar Seconds
+    `);
+
+    const content = generateSchemaTypes(schema, {
+      customScalars: {
+        Seconds: {
+          name: 'number',
+        },
+      },
+    }).get('index.ts');
+
+    expect(content).toContain(stripIndent`
+      export type Seconds = number;
+    `);
+
+    expect(content).not.toContain('import { number ');
+  });
+
   it('prints an input object in the index file', () => {
     const schema = buildSchema(`
       input Input {


### PR DESCRIPTION
I have a custom type named `Seconds` in my GraphQL schema that is really just an `Int`. The current implementation of `graphql-typescript-definitions` doesn't allow this. So here's a PR that lets you alias any built-in JS type.

The `package` property in custom-scalars is now optional. If left out then no import will be performed, and the `name` is assumed to be a globally available type.

e.g.

    --custom-scalars '{"Seconds": {"name": "number"}}'

Will become:

    export type Seconds = number;