### PR TITLE
[graphql-fixtures] adding new GraphQLFillerData type construct

### DIFF
--- a/packages/graphql-fixtures/README.md
+++ b/packages/graphql-fixtures/README.md
@@ -20,7 +20,7 @@ yarn add graphql-fixtures --dev
 
 Returns a function that will be used to create object fixtures. This function takes the GraphQL schema (which will be used to generate the correct type of data given the document), and an optional object with the following properties:
 
-* `resolvers`: an object whose keys are names of types in the passed `schema`, and whose values are functions that return a fixture version of that type. This function can return a partial fixture; the default resolvers will then fill the remainder of the object. The function will be called two arguments: the GraphQL request (including variables), and details about the type and field currently being filled. You could use this to, for example, create dynamic values for a type based on the object in which it resides:
+- `resolvers`: an object whose keys are names of types in the passed `schema`, and whose values are functions that return a fixture version of that type. This function can return a partial fixture; the default resolvers will then fill the remainder of the object. The function will be called two arguments: the GraphQL request (including variables), and details about the type and field currently being filled. You could use this to, for example, create dynamic values for a type based on the object in which it resides:
 
   ```ts
   let currentID = 1;
@@ -43,7 +43,7 @@ function fill<Data, Variables, PartialData>(
   // an import from a .graphql file and an asynchronous query component
   // from `@shopify/react-graphql`
   operation: GraphQLOperation<Data, Variables, PartialData>,
-  data?: DeepThunk<PartialData>,
+  data?: GraphQLFillerData<GraphQLOperation<Data, Variables, PartialData>>,
 ): (request: GraphQLRequest) => Data;
 ```
 

--- a/packages/graphql-fixtures/src/fill.ts
+++ b/packages/graphql-fixtures/src/fill.ts
@@ -87,6 +87,21 @@ export type DeepThunk<T, Data, Variables, DeepPartial> = T extends object
     }
   : T;
 
+export type GraphQLFillerData<
+  Operation extends GraphQLOperation
+> = Operation extends GraphQLOperation<
+  infer Data,
+  infer Variables,
+  infer PartialData
+>
+  ? Thunk<
+      DeepThunk<PartialData, Data, Variables, PartialData>,
+      Data,
+      Variables,
+      PartialData
+    >
+  : never;
+
 export interface Options {
   resolvers?: {[key: string]: Resolver};
 }
@@ -129,12 +144,7 @@ export function createFiller(
 
   return function fill<Data, Variables, PartialData>(
     _document: GraphQLOperation<Data, Variables, PartialData>,
-    data?: Thunk<
-      DeepThunk<PartialData, Data, Variables, PartialData>,
-      Data,
-      Variables,
-      PartialData
-    >,
+    data?: GraphQLFillerData<GraphQLOperation<Data, Variables, PartialData>>,
   ): (request: GraphQLRequest<Data, Variables, PartialData>) => Data {
     return (request: GraphQLRequest<Data, Variables, PartialData>) => {
       const {operationName, query} = request;


### PR DESCRIPTION
This new type construct simplifies how we can define the shape of mocked data that will be used for filling a GraphQL response. Instead of requiring all individual GraphQL document types, we can define the shape of mocked data via `type FooData = GraphQLFillerData<typeof fooQuery>`. This is particularly useful for building more composable filling wrapper functions where there are multiple schemas involved:

```tsx
function createFilledOperations({
  fooData = {},
  barData = {},
}: {
  fooData?: GraphQLFillerData<typeof fooQuery>,
  barData?: GraphQLFillerData<typeof barQuery>,
} = {}) {
  return {
    fooQuery: fillGraphQL(fooQuery, {data: 'default', ...fooData}),
    barQuery: fillGraphQL(barQuery, {data: 'default', ...barData}),
  };
}
```

Now we can easily call `createFilledOperations` with either static or dynamic data injections

```tsx
// defaults only
createFilledOperations();

// static override
createFilledOperations({
  fooData: {data: 'override'},
});

// dynamic override
createFilledOperations({
  fooData: {data: 'override'},
  barData({variables: {arg}}) {
    return {data: arg ? 'arg' : 'empty'};
  },
});
```