### PR TITLE
add generateId option to graphql-mini-transforms

### DIFF
--- a/packages/graphql-mini-transforms/README.md
+++ b/packages/graphql-mini-transforms/README.md
@@ -61,7 +61,7 @@ fragment ProductVariantId on ProductVariant {
 
 #### Options
 
-##### simple
+##### `simple`
 
 This option changes the shape of the value exported from `.graphql` files. By default, a `graphql-typed` `DocumentNode` is exported, but when `simple` is set to `true`, a `SimpleDocument` is exported instead. This representation of GraphQL documents is smaller than a full `DocumentNode`, but generally won’t work with normalized GraphQL caches.
 
@@ -82,11 +82,9 @@ module.exports = {
 
 If this option is set to `true`, you should also use the `jest-simple` transformer for Jest, and the `--export-format simple` flag for `graphql-typescript-definitions`.
 
-##### generateId
+##### `generateId`
 
-This option changes the identifier value used. By default the hash of the minified GraphQL document is used as the identifier value, but when `generateId` is provided
-the return value is used as the identifier value. `generateId` should be a function which takes a single parameter, the normalized GraphQL document source as a string,
-and it should return a string value.
+This option changes the identifier value used. By default the hash of the minified GraphQL document is used as the identifier value, but when `generateId` is provided the return value is used as the identifier value. `generateId` should be a function which takes a single parameter, the normalized GraphQL document source as a string, and it should return a string value.
 
 ```js
 module.exports = {

--- a/packages/graphql-mini-transforms/README.md
+++ b/packages/graphql-mini-transforms/README.md
@@ -61,7 +61,9 @@ fragment ProductVariantId on ProductVariant {
 
 #### Options
 
-This loader accepts a single option, `simple`. This option changes the shape of the value exported from `.graphql` files. By default, a `graphql-typed` `DocumentNode` is exported, but when `simple` is set to `true`, a `SimpleDocument` is exported instead. This representation of GraphQL documents is smaller than a full `DocumentNode`, but generally won’t work with normalized GraphQL caches.
+##### simple
+
+This option changes the shape of the value exported from `.graphql` files. By default, a `graphql-typed` `DocumentNode` is exported, but when `simple` is set to `true`, a `SimpleDocument` is exported instead. This representation of GraphQL documents is smaller than a full `DocumentNode`, but generally won’t work with normalized GraphQL caches.
 
 ```js
 module.exports = {
@@ -79,6 +81,27 @@ module.exports = {
 ```
 
 If this option is set to `true`, you should also use the `jest-simple` transformer for Jest, and the `--export-format simple` flag for `graphql-typescript-definitions`.
+
+##### generateId
+
+This option changes the identifier value used. By default the hash of the minified GraphQL document is used as the identifier value, but when `generateId` is provided
+the return value is used as the identifier value. `generateId` should be a function which takes a single parameter, the normalized GraphQL document source as a string,
+and it should return a string value.
+
+```js
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.(graphql|gql)$/,
+        use: 'graphql-mini-transforms/webpack',
+        exclude: /node_modules/,
+        options: {generateId: normalizedSource => someHash(normalizedSource)},
+      },
+    ],
+  },
+};
+```
 
 ### Jest
 

--- a/packages/graphql-mini-transforms/README.md
+++ b/packages/graphql-mini-transforms/README.md
@@ -84,7 +84,7 @@ If this option is set to `true`, you should also use the `jest-simple` transform
 
 ##### `generateId`
 
-This option changes the identifier value used. By default the hash of the minified GraphQL document is used as the identifier value, but when `generateId` is provided the return value is used as the identifier value. `generateId` should be a function which takes a single parameter, the normalized GraphQL document source as a string, and it should return a string value.
+This option changes the identifier value used. By default the hash of the minified GraphQL document is used as the identifier value, but when `generateId` is provided the return value is used as the identifier value. `generateId` should be a function which takes a single parameter, an object with the normalized GraphQL document source as a string under the `source` key, and it should return a string value.
 
 ```js
 module.exports = {
@@ -94,7 +94,7 @@ module.exports = {
         test: /\.(graphql|gql)$/,
         use: 'graphql-mini-transforms/webpack',
         exclude: /node_modules/,
-        options: {generateId: normalizedSource => someHash(normalizedSource)},
+        options: {generateId: ({source}) => someHash(source)},
       },
     ],
   },

--- a/packages/graphql-mini-transforms/package.json
+++ b/packages/graphql-mini-transforms/package.json
@@ -34,6 +34,7 @@
   "devDependencies": {
     "@types/common-tags": "^1.8.0",
     "@types/loader-utils": "^1.1.3",
+    "@types/schema-utils": "^2.4.0",
     "common-tags": "^1.8.0"
   },
   "dependencies": {
@@ -43,6 +44,7 @@
     "fs-extra": "^9.0.0",
     "graphql": ">=14.5.0 <15.0.0",
     "graphql-typed": "^0.6.1",
-    "loader-utils": "^2.0.0"
+    "loader-utils": "^2.0.0",
+    "schema-utils": "^2.7.1"
   }
 }

--- a/packages/graphql-mini-transforms/src/document.ts
+++ b/packages/graphql-mini-transforms/src/document.ts
@@ -16,16 +16,20 @@ import {DocumentNode, SimpleDocument} from 'graphql-typed';
 const IMPORT_REGEX = /^#import\s+['"]([^'"]*)['"];?[\s\n]*/gm;
 const DEFAULT_NAME = 'Operation';
 
-function defaultGenerateId(normalizedSource: string) {
+export interface GenerateIdArguments {
+  source: string;
+}
+
+function defaultGenerateId({source}: GenerateIdArguments) {
   // This ID is a hash of the full file contents that are part of the document,
   // including other documents that are injected in, but excluding any unused
   // fragments. This is useful for things like persisted queries.
-  return createHash('sha256').update(normalizedSource).digest('hex');
+  return createHash('sha256').update(source).digest('hex');
 }
 
 export interface CleanDocumentOptions {
   removeUnused?: boolean;
-  generateId?: (normalizedSource: string) => string;
+  generateId?: (args: GenerateIdArguments) => string;
 }
 
 export function cleanDocument(
@@ -50,8 +54,8 @@ export function cleanDocument(
 
   const id =
     generateId === undefined
-      ? defaultGenerateId(normalizedSource)
-      : generateId(documentSource);
+      ? defaultGenerateId({source: normalizedSource})
+      : generateId({source: documentSource});
 
   Reflect.defineProperty(normalizedDocument, 'id', {
     value: id,

--- a/packages/graphql-mini-transforms/src/document.ts
+++ b/packages/graphql-mini-transforms/src/document.ts
@@ -16,9 +16,26 @@ import {DocumentNode, SimpleDocument} from 'graphql-typed';
 const IMPORT_REGEX = /^#import\s+['"]([^'"]*)['"];?[\s\n]*/gm;
 const DEFAULT_NAME = 'Operation';
 
+function defaultGenerateId(normalizedSource: string) {
+  // This ID is a hash of the full file contents that are part of the document,
+  // including other documents that are injected in, but excluding any unused
+  // fragments. This is useful for things like persisted queries.
+  return createHash('sha256')
+    .update(minifySource(normalizedSource))
+    .digest('hex');
+}
+
+export interface CleanDocumentOptions {
+  removeUnused?: boolean;
+  generateId?: (normalizedSource: string) => string;
+}
+
 export function cleanDocument(
   document: UntypedDocumentNode,
-  {removeUnused = true} = {},
+  {
+    removeUnused = true,
+    generateId = defaultGenerateId,
+  }: CleanDocumentOptions = {},
 ): DocumentNode<any, any, any> {
   if (removeUnused) {
     removeUnusedDefinitions(document);
@@ -35,10 +52,7 @@ export function cleanDocument(
     stripLoc(definition);
   }
 
-  // This ID is a hash of the full file contents that are part of the document,
-  // including other documents that are injected in, but excluding any unused
-  // fragments. This is useful for things like persisted queries.
-  const id = createHash('sha256').update(normalizedSource).digest('hex');
+  const id = generateId(print(document));
 
   Reflect.defineProperty(normalizedDocument, 'id', {
     value: id,

--- a/packages/graphql-mini-transforms/src/document.ts
+++ b/packages/graphql-mini-transforms/src/document.ts
@@ -16,15 +16,6 @@ import {DocumentNode, SimpleDocument} from 'graphql-typed';
 const IMPORT_REGEX = /^#import\s+['"]([^'"]*)['"];?[\s\n]*/gm;
 const DEFAULT_NAME = 'Operation';
 
-function defaultGenerateId(normalizedSource: string) {
-  // This ID is a hash of the full file contents that are part of the document,
-  // including other documents that are injected in, but excluding any unused
-  // fragments. This is useful for things like persisted queries.
-  return createHash('sha256')
-    .update(minifySource(normalizedSource))
-    .digest('hex');
-}
-
 export interface CleanDocumentOptions {
   removeUnused?: boolean;
   generateId?: (normalizedSource: string) => string;
@@ -32,10 +23,7 @@ export interface CleanDocumentOptions {
 
 export function cleanDocument(
   document: UntypedDocumentNode,
-  {
-    removeUnused = true,
-    generateId = defaultGenerateId,
-  }: CleanDocumentOptions = {},
+  {removeUnused = true, generateId}: CleanDocumentOptions = {},
 ): DocumentNode<any, any, any> {
   if (removeUnused) {
     removeUnusedDefinitions(document);
@@ -53,7 +41,18 @@ export function cleanDocument(
     stripLoc(definition);
   }
 
-  const id = generateId(documentSource);
+  let id: string;
+
+  if (generateId === undefined) {
+    // This ID is a hash of the full file contents that are part of the document,
+    // including other documents that are injected in, but excluding any unused
+    // fragments. This is useful for things like persisted queries.
+    id = createHash('sha256')
+      .update(minifySource(normalizedSource))
+      .digest('hex');
+  } else {
+    id = generateId(documentSource);
+  }
 
   Reflect.defineProperty(normalizedDocument, 'id', {
     value: id,

--- a/packages/graphql-mini-transforms/src/document.ts
+++ b/packages/graphql-mini-transforms/src/document.ts
@@ -45,14 +45,15 @@ export function cleanDocument(
     addTypename(definition);
   }
 
-  const normalizedSource = minifySource(print(document));
+  const documentSource = print(document);
+  const normalizedSource = minifySource(documentSource);
   const normalizedDocument = parse(normalizedSource);
 
   for (const definition of normalizedDocument.definitions) {
     stripLoc(definition);
   }
 
-  const id = generateId(print(document));
+  const id = generateId(documentSource);
 
   Reflect.defineProperty(normalizedDocument, 'id', {
     value: id,

--- a/packages/graphql-mini-transforms/src/webpack.ts
+++ b/packages/graphql-mini-transforms/src/webpack.ts
@@ -5,12 +5,7 @@ import {parse, DocumentNode} from 'graphql';
 import {getOptions} from 'loader-utils';
 import validateOptions from 'schema-utils';
 
-import {
-  cleanDocument,
-  extractImports,
-  toSimpleDocument,
-  CleanDocumentOptions,
-} from './document';
+import {cleanDocument, extractImports, toSimpleDocument} from './document';
 
 interface Options {
   generateId?: (normalizedSource: string) => string;
@@ -36,7 +31,7 @@ export default async function graphQLLoader(
   this.cacheable();
 
   const done = this.async();
-  const options = {simple: false, ...getOptions(this)} as Options;
+  const options: Options = {simple: false, ...getOptions(this)};
 
   validateOptions(schema, options, {name: '@shopify/graphql-mini-transforms'});
 
@@ -46,14 +41,10 @@ export default async function graphQLLoader(
     );
   }
 
-  const cleanDocumentOptions = {
-    generateId: options.generateId,
-  } as CleanDocumentOptions;
-
   try {
     const document = cleanDocument(
       await loadDocument(source, this.context, this),
-      cleanDocumentOptions,
+      {generateId: options.generateId},
     );
     const exported = options.simple ? toSimpleDocument(document) : document;
 

--- a/packages/graphql-mini-transforms/src/webpack.ts
+++ b/packages/graphql-mini-transforms/src/webpack.ts
@@ -5,10 +5,15 @@ import {parse, DocumentNode} from 'graphql';
 import {getOptions} from 'loader-utils';
 import validateOptions from 'schema-utils';
 
-import {cleanDocument, extractImports, toSimpleDocument} from './document';
+import {
+  cleanDocument,
+  extractImports,
+  toSimpleDocument,
+  GenerateIdArguments,
+} from './document';
 
 interface Options {
-  generateId?: (normalizedSource: string) => string;
+  generateId?: (args: GenerateIdArguments) => string;
   simple?: boolean;
 }
 

--- a/packages/graphql-mini-transforms/tests/webpack.test.ts
+++ b/packages/graphql-mini-transforms/tests/webpack.test.ts
@@ -70,6 +70,14 @@ describe('graphql-mini-transforms/webpack', () => {
     );
   });
 
+  it('has option for custom ID generate function', async () => {
+    const result = await extractDocumentExport(
+      `query Shop { shop { id } }`,
+      createLoaderContext({query: {generateId: () => 'foo'}}),
+    );
+    expect(result).toHaveProperty('id', 'foo');
+  });
+
   describe('import', () => {
     it('adds the resolved import as a dependency', async () => {
       const context = '/app/';

--- a/packages/graphql-mini-transforms/tests/webpack.test.ts
+++ b/packages/graphql-mini-transforms/tests/webpack.test.ts
@@ -92,7 +92,7 @@ describe('graphql-mini-transforms/webpack', () => {
             }
           `,
         ),
-      })
+      }),
     );
     expect(result).toHaveProperty('id', 'foo');
   });

--- a/packages/graphql-mini-transforms/tests/webpack.test.ts
+++ b/packages/graphql-mini-transforms/tests/webpack.test.ts
@@ -70,10 +70,26 @@ describe('graphql-mini-transforms/webpack', () => {
     );
   });
 
-  it('has option for custom ID generate function', async () => {
+  it('uses the generateId option for the document ID when provided', async () => {
+    // Mock function can't be called directly due to API schema validation, see
+    // https://github.com/facebook/jest/issues/6329
+    const _generateId = jest.fn((_) => 'foo');
+    const generateId = (src: string) => _generateId(src);
     const result = await extractDocumentExport(
       `query Shop { shop { id } }`,
-      createLoaderContext({query: {generateId: () => 'foo'}}),
+      createLoaderContext({query: {generateId}}),
+    );
+    expect(_generateId).toHaveBeenCalledWith(
+      expect.toStartWith(
+        stripIndent`
+          query Shop {
+            shop {
+              id
+              __typename
+            }
+          }
+        `,
+      ),
     );
     expect(result).toHaveProperty('id', 'foo');
   });

--- a/packages/graphql-mini-transforms/tests/webpack.test.ts
+++ b/packages/graphql-mini-transforms/tests/webpack.test.ts
@@ -4,6 +4,7 @@ import {createHash} from 'crypto';
 import {loader} from 'webpack';
 import {stripIndent} from 'common-tags';
 
+import {GenerateIdArguments} from '../src/document';
 import graphQLLoader from '../src/webpack';
 
 describe('graphql-mini-transforms/webpack', () => {
@@ -74,22 +75,24 @@ describe('graphql-mini-transforms/webpack', () => {
     // Mock function can't be called directly due to API schema validation, see
     // https://github.com/facebook/jest/issues/6329
     const _generateId = jest.fn((_) => 'foo');
-    const generateId = (src: string) => _generateId(src);
+    const generateId = (args: GenerateIdArguments) => _generateId(args);
     const result = await extractDocumentExport(
       `query Shop { shop { id } }`,
       createLoaderContext({query: {generateId}}),
     );
     expect(_generateId).toHaveBeenCalledWith(
-      expect.toStartWith(
-        stripIndent`
-          query Shop {
-            shop {
-              id
-              __typename
+      expect.objectContaining({
+        source: expect.toStartWith(
+          stripIndent`
+            query Shop {
+              shop {
+                id
+                __typename
+              }
             }
-          }
-        `,
-      ),
+          `,
+        ),
+      })
     );
     expect(result).toHaveProperty('id', 'foo');
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -720,6 +720,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.4.tgz#38fd73ddfd9b55abb1e1b2ed578cb55bd7b7d339"
   integrity sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==
 
+"@types/json-schema@^7.0.5":
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.6.tgz#f4c7ec43e81b319a9815115031709f26987891f0"
+  integrity sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==
+
 "@types/loader-utils@^1.1.3":
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@types/loader-utils/-/loader-utils-1.1.3.tgz#82b9163f2ead596c68a8c03e450fbd6e089df401"
@@ -750,6 +755,13 @@
   version "1.19.1"
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-1.19.1.tgz#33509849f8e679e4add158959fdb086440e9553f"
   integrity sha512-5qOlnZscTn4xxM5MeGXAMOsIOIKIbh9e85zJWfBRVPlRMEVawzoPhINYbRGkBZCI8LxvBe7tJCdWiarA99OZfQ==
+
+"@types/schema-utils@^2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@types/schema-utils/-/schema-utils-2.4.0.tgz#9983012045d541dcee053e685a27c9c87c840fcd"
+  integrity sha512-454hrj5gz/FXcUE20ygfEiN4DxZ1sprUo0V1gqIqkNZ/CzoEzAZEll2uxMsuyz6BYjiQan4Aa65xbTemfzW9hQ==
+  dependencies:
+    schema-utils "*"
 
 "@types/source-list-map@*":
   version "0.1.2"
@@ -909,10 +921,25 @@ add-stream@^1.0.0:
   resolved "https://registry.yarnpkg.com/add-stream/-/add-stream-1.0.0.tgz#6a7990437ca736d5e1288db92bd3266d5f5cb2aa"
   integrity sha1-anmQQ3ynNtXhKI25K9MmbV9csqo=
 
+ajv-keywords@^3.5.2:
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.2.tgz#31f29da5ab6e00d1c2d329acf7b5929614d5014d"
+  integrity sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==
+
 ajv@^6.10.0, ajv@^6.10.2, ajv@^6.5.5:
   version "6.12.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.0.tgz#06d60b96d87b8454a5adaba86e7854da629db4b7"
   integrity sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
+ajv@^6.12.4:
+  version "6.12.5"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.5.tgz#19b0e8bae8f476e5ba666300387775fb1a00a4da"
+  integrity sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==
   dependencies:
     fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"
@@ -5883,6 +5910,15 @@ saxes@^3.1.9:
   integrity sha512-Ydydq3zC+WYDJK1+gRxRapLIED9PWeSuuS41wqyoRmzvhhh9nc+QQrVMKJYzJFULazeGhzSV0QleN2wD3boh2g==
   dependencies:
     xmlchars "^2.1.1"
+
+schema-utils@*, schema-utils@^2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-2.7.1.tgz#1ca4f32d1b24c590c203b8e7a50bf0ea4cd394d7"
+  integrity sha512-SHiNtMOUGWBQJwzISiVYKu82GiV4QYGePp3odlY1tuKO7gPtphAT5R/py0fA6xtbgLL/RvtJZnU9b8s0F1q0Xg==
+  dependencies:
+    "@types/json-schema" "^7.0.5"
+    ajv "^6.12.4"
+    ajv-keywords "^3.5.2"
 
 "semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@^5.4.1, semver@^5.5.0:
   version "5.7.1"


### PR DESCRIPTION
Effectively the same as the `generateId` option from `graphql-persisted-document-loader`.

I've got a use-case where I'd like to make the ID a signature of the hash, rather than just the hash, so that the server can trust queries presented by the client, since the IDs were signed at build-time. Removes the need to distribute a generated mapping like that from `@shopify/webpack-persisted-graphql-plugin`.

Being able to customize the generated ID would make this possible, and it's a pretty small change.