### PR TITLE
Fix random sizing of lists

### DIFF
--- a/packages/graphql-fixtures/src/fill.ts
+++ b/packages/graphql-fixtures/src/fill.ts
@@ -504,8 +504,9 @@ export function list<T = {}, Data = {}, Variables = {}, DeepPartial = {}>(
   size: number | [number, number],
   partial?: Thunk<T, Data, Variables, DeepPartial>,
 ): Thunk<T, Data, Variables, DeepPartial>[] {
-  const finalSize =
-    typeof size === 'number' ? size : size[Math.round(Math.random())];
+  const randomSize = ([min, max]: number[]) =>
+    Math.round(Math.random() * (max - min) + min);
+  const finalSize = typeof size === 'number' ? size : randomSize(size);
   return Array<Thunk<T, Data, Variables, DeepPartial>>(finalSize).fill(
     partial as Thunk<T, Data, Variables, DeepPartial>,
   );

--- a/packages/graphql-fixtures/tests/fill.test.ts
+++ b/packages/graphql-fixtures/tests/fill.test.ts
@@ -1220,6 +1220,44 @@ describe('createFiller()', () => {
       });
     });
 
+    it('fills a list with a random size and respect the min range value', () => {
+      jest.spyOn(Math, 'random').mockReturnValue(0);
+      const fill = createFillerForSchema(`
+        type Query {
+          initials: [String!]!
+        }
+      `);
+
+      const document = createDocument<{initials: string[]}>(`
+        query Details {
+          initials
+        }
+      `);
+
+      expect(fill(document, {initials: list([1, 3])})).toStrictEqual({
+        initials: [expect.any(String)],
+      });
+    });
+
+    it('fills a list with a random size and respect the max range value', () => {
+      jest.spyOn(Math, 'random').mockReturnValue(1);
+      const fill = createFillerForSchema(`
+        type Query {
+          initials: [String!]!
+        }
+      `);
+
+      const document = createDocument<{initials: string[]}>(`
+        query Details {
+          initials
+        }
+      `);
+
+      expect(fill(document, {initials: list([1, 3])})).toStrictEqual({
+        initials: [expect.any(String), expect.any(String), expect.any(String)],
+      });
+    });
+
     it('fills nested lists', () => {
       const fill = createFillerForSchema(`
         type Query {


### PR DESCRIPTION
The way this was implemented before we would get only two possible sizes for the random list.
For example if I were to use list with `list([2,6])`, where we do `size[Math.round(Math.random())]` the only two possible indexes are 0 and 1, so `finalSize` in this case would be either 2 or 6, but would never be anything in between. So sometimes we would have an array of size 2, sometimes of size 6, but nothing else.

In my proposed implementation I take a random number from 0 to the difference between min and max by multiplying `Math.random` with that difference and add the result to the min value. This would give us a random number between the two values as advertised in the docs:
> an array randomly sized in that range

I hope this helps.

Regards.