### PR TITLE
Update README.md with correct `.graphqlconfig`

### DIFF
--- a/packages/graphql-typescript-definitions/README.md
+++ b/packages/graphql-typescript-definitions/README.md
@@ -97,7 +97,7 @@ A project configuration with a `schemaTypesPath` override
 ```json
 {
   "schemaPath": "build/schema.json",
-  "includes": "app/**/*.graphql",
+  "includes": ["app/**/*.graphql"],
   "extensions": {
     "schemaTypesPath": "app/bar/types/graphql"
   }


### PR DESCRIPTION
Hi there! Firstly, thank you for this project. As I was getting this set up for a project of my own, I noticed that there was a slight error in the example `.graphqlconfig` in the README. The `includes` field should be an array of globs, not just a string. The downstream `graphql-config` package basically does a call that looks like `(this.config.includes || []).map(...)`, and this obviously fails in the case of just a single string `includes` field. 

Let me know if I need to do anything else to get this small change through. Thanks!