### PR TITLE
"Simple" document types

### DIFF
--- a/packages/graphql-mini-transforms/README.md
+++ b/packages/graphql-mini-transforms/README.md
@@ -59,6 +59,27 @@ fragment ProductVariantId on ProductVariant {
 }
 ```
 
+#### Options
+
+This loader accepts a single option, `simple`. This option changes the shape of the value exported from `.graphql` files. By default, a `graphql-typed` `DocumentNode` is exported, but when `simple` is set to `true`, a `SimpleDocument` is exported instead. This representation of GraphQL documents is smaller than a full `DocumentNode`, but generally won’t work with normalized GraphQL caches.
+
+```js
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.(graphql|gql)$/,
+        use: 'graphql-mini-transforms/webpack',
+        exclude: /node_modules/,
+        options: {simple: true},
+      },
+    ],
+  },
+};
+```
+
+If this option is set to `true`, you should also use the `jest-simple` transformer for Jest, and the `--export-format simple` flag for `graphql-typescript-definitions`.
+
 ### Jest
 
 This package also provides a transformer for GraphQL files in Jest. To use the transformer, add a reference to it in your Jest configuration’s `transform` option:
@@ -67,6 +88,16 @@ This package also provides a transformer for GraphQL files in Jest. To use the t
 module.exports = {
   transform: {
     '\\.(gql|graphql)$': 'graphql-mini-transforms/jest',
+  },
+};
+```
+
+If you want to get the same output as the `simple` option of the webpack loader, you can instead use the `jest-simple` loader transformer:
+
+```js
+module.exports = {
+  transform: {
+    '\\.(gql|graphql)$': 'graphql-mini-transforms/jest-simple',
   },
 };
 ```
@@ -86,5 +117,3 @@ We wrote something custom in order to get the following benefits:
 ## Related projects
 
 - [next-plugin-mini-graphql](https://www.npmjs.com/package/next-plugin-mini-graphql) - Provides [Next.js](https://nextjs.org/) support for `.graphql` files using `graphql-mini-transforms`
-
-

--- a/packages/graphql-mini-transforms/jest-simple.js
+++ b/packages/graphql-mini-transforms/jest-simple.js
@@ -1,0 +1,1 @@
+module.exports = require('./lib/jest-simple');

--- a/packages/graphql-mini-transforms/package.json
+++ b/packages/graphql-mini-transforms/package.json
@@ -31,14 +31,16 @@
     "prepublishOnly": "yarn build"
   },
   "devDependencies": {
-    "@types/common-tags": "1.8.0",
-    "common-tags": "1.8.0"
+    "@types/common-tags": "^1.8.0",
+    "@types/loader-utils": "^1.1.3",
+    "common-tags": "^1.8.0"
   },
   "dependencies": {
     "@jest/transform": "^25.3.0",
     "@types/fs-extra": "^8.1.0",
     "@types/webpack": "^4.41.11",
     "fs-extra": "^9.0.0",
-    "graphql": ">=14.5.0 <15.0.0"
+    "graphql": ">=14.5.0 <15.0.0",
+    "loader-utils": "^2.0.0"
   }
 }

--- a/packages/graphql-mini-transforms/package.json
+++ b/packages/graphql-mini-transforms/package.json
@@ -41,6 +41,7 @@
     "@types/webpack": "^4.41.11",
     "fs-extra": "^9.0.0",
     "graphql": ">=14.5.0 <15.0.0",
+    "graphql-typed": "^0.5.0",
     "loader-utils": "^2.0.0"
   }
 }

--- a/packages/graphql-mini-transforms/src/jest-simple.ts
+++ b/packages/graphql-mini-transforms/src/jest-simple.ts
@@ -1,0 +1,58 @@
+import {createHash} from 'crypto';
+
+import {readFileSync} from 'fs-extra';
+import {Transformer} from '@jest/transform';
+import {parse} from 'graphql';
+
+import {extractImports} from './document';
+
+const THIS_FILE = readFileSync(__filename);
+
+const transformer: Transformer = {
+  getCacheKey(fileData, filename) {
+    return createHash('md5')
+      .update(THIS_FILE)
+      .update(fileData)
+      .update(filename)
+      .digest('hex');
+  },
+  process(rawSource) {
+    const {imports, source} = extractImports(rawSource);
+
+    const utilityImports = `
+      var {print, parse} = require('graphql');
+      var {cleanDocument, toSimpleDocument} = require(${JSON.stringify(
+        `${__dirname}/document.js`,
+      )});
+    `;
+
+    const importSource = imports
+      .map(
+        (imported, index) =>
+          `var importedDocument${index} = require(${JSON.stringify(
+            imported,
+          )});`,
+      )
+      .join('\n');
+
+    const appendDefinitionsSource = imports
+      .map(
+        (_, index) =>
+          `document.definitions.push.apply(document.definitions, parse(importedDocument${index}.source).definitions);`,
+      )
+      .join('\n');
+
+    return `
+      ${utilityImports}
+      ${importSource}
+
+      var document = ${JSON.stringify(parse(source))};
+
+      ${appendDefinitionsSource}
+
+      module.exports = toSimpleDocument(cleanDocument(document, {removeUnused: false}));
+    `;
+  },
+};
+
+export = transformer;

--- a/packages/graphql-mini-transforms/tests/webpack.test.ts
+++ b/packages/graphql-mini-transforms/tests/webpack.test.ts
@@ -201,7 +201,7 @@ describe('graphql-mini-transforms/webpack', () => {
     });
   });
 
-  describe('raw', () => {
+  describe('simple', () => {
     it('has a source property that is the minified source', async () => {
       const originalSource = stripIndent`
         # Comments should go away
@@ -221,7 +221,7 @@ describe('graphql-mini-transforms/webpack', () => {
       expect(
         await extractDocumentExport(
           originalSource,
-          createLoaderContext({query: {raw: true}}),
+          createLoaderContext({query: {simple: true}}),
         ),
       ).toHaveProperty('source', expectedSource);
     });
@@ -229,7 +229,7 @@ describe('graphql-mini-transforms/webpack', () => {
     it('has an id property that is a sha256 hash of the query document', async () => {
       const result = await extractDocumentExport(
         `query Shop { shop { id } }`,
-        createLoaderContext({query: {raw: true}}),
+        createLoaderContext({query: {simple: true}}),
       );
 
       expect(result).toHaveProperty(
@@ -241,7 +241,7 @@ describe('graphql-mini-transforms/webpack', () => {
     it('has a name property that is the name of the first operation', async () => {
       const result = await extractDocumentExport(
         `query Shop { shop { id } }`,
-        createLoaderContext({query: {raw: true}}),
+        createLoaderContext({query: {simple: true}}),
       );
 
       expect(result).toHaveProperty('name', 'Shop');
@@ -250,7 +250,7 @@ describe('graphql-mini-transforms/webpack', () => {
     it('has an undefined name when there are no named operations', async () => {
       const result = await extractDocumentExport(
         `query { shop { id } }`,
-        createLoaderContext({query: {raw: true}}),
+        createLoaderContext({query: {simple: true}}),
       );
 
       expect(result).toHaveProperty('name', undefined);
@@ -316,6 +316,8 @@ async function extractDocumentExport(
   loader = createLoaderContext(),
 ) {
   const result = await simulateRun(source, loader);
+
+  // eslint-disable-next-line no-eval
   return eval(result.replace(/^export default /, '').replace(/;$/, ''));
 }
 

--- a/packages/graphql-mini-transforms/tests/webpack.test.ts
+++ b/packages/graphql-mini-transforms/tests/webpack.test.ts
@@ -200,9 +200,66 @@ describe('graphql-mini-transforms/webpack', () => {
       expect(body).not.toContain('fragment FooFragment on Shop');
     });
   });
+
+  describe('raw', () => {
+    it('has a source property that is the minified source', async () => {
+      const originalSource = stripIndent`
+        # Comments should go away
+        # As should extra space
+        query Shop ( $id : ID! , $first: Number! ) {
+          # Most whitespace should go too
+          shop ( id:   $id, first: $first ) {
+            # Should also minify selection sets
+            id,
+            name,
+          }
+        }
+      `;
+
+      const expectedSource = `query Shop($id:ID!,$first:Number!){shop(id:$id,first:$first){id name __typename}}`;
+
+      expect(
+        await extractDocumentExport(
+          originalSource,
+          createLoaderContext({query: {raw: true}}),
+        ),
+      ).toHaveProperty('source', expectedSource);
+    });
+
+    it('has an id property that is a sha256 hash of the query document', async () => {
+      const result = await extractDocumentExport(
+        `query Shop { shop { id } }`,
+        createLoaderContext({query: {raw: true}}),
+      );
+
+      expect(result).toHaveProperty(
+        'id',
+        createHash('sha256').update(result.source).digest('hex'),
+      );
+    });
+
+    it('has a name property that is the name of the first operation', async () => {
+      const result = await extractDocumentExport(
+        `query Shop { shop { id } }`,
+        createLoaderContext({query: {raw: true}}),
+      );
+
+      expect(result).toHaveProperty('name', 'Shop');
+    });
+
+    it('has an undefined name when there are no named operations', async () => {
+      const result = await extractDocumentExport(
+        `query { shop { id } }`,
+        createLoaderContext({query: {raw: true}}),
+      );
+
+      expect(result).toHaveProperty('name', undefined);
+    });
+  });
 });
 
 interface Options {
+  query?: any;
   context?: string;
   resolve?(context: string, imported: string): string | Error;
   readFile?(file: string): string | Error;
@@ -211,12 +268,14 @@ interface Options {
 // This is a limited subset of the loader API that we actually use in our
 // loader.
 function createLoaderContext({
+  query = {},
   context = __dirname,
   readFile = () => '',
   resolve = (context, imported) => path.resolve(context, imported),
 }: Options = {}): loader.LoaderContext {
   return {
     context,
+    query,
     fs: {
       readFile(
         file: string,
@@ -257,7 +316,7 @@ async function extractDocumentExport(
   loader = createLoaderContext(),
 ) {
   const result = await simulateRun(source, loader);
-  return JSON.parse(result.replace(/^export default /, '').replace(/;$/, ''));
+  return eval(result.replace(/^export default /, '').replace(/;$/, ''));
 }
 
 function simulateRun(source: string, loader = createLoaderContext()) {

--- a/packages/graphql-typed/index.ts
+++ b/packages/graphql-typed/index.ts
@@ -16,7 +16,16 @@ export interface GraphQLOperation<Data = {}, Variables = {}, DeepPartial = {}> {
 
 export interface DocumentNode<Data = {}, Variables = {}, DeepPartial = {}>
   extends BaseDocumentNode,
-    GraphQLOperation<Data, Variables, DeepPartial> {}
+    GraphQLOperation<Data, Variables, DeepPartial> {
+  readonly id: string;
+}
+
+export interface SimpleDocument<Data = {}, Variables = {}, DeepPartial = {}>
+  extends GraphQLOperation<Data, Variables, DeepPartial> {
+  readonly id: string;
+  readonly name?: string;
+  readonly source: string;
+}
 
 export type GraphQLData<T> = T extends GraphQLOperation<infer Data, any, any>
   ? Data
@@ -41,4 +50,4 @@ export type GraphQLDeepPartial<T> = T extends GraphQLOperation<
 export const parse: <Data = {}, Variables = {}, DeepPartial = {}>(
   source: string | Source,
   options?: ParseOptions,
-) => DocumentNode<Data, Variables, DeepPartial> = graphQLParse;
+) => DocumentNode<Data, Variables, DeepPartial> = graphQLParse as any;

--- a/packages/graphql-typescript-definitions/README.md
+++ b/packages/graphql-typescript-definitions/README.md
@@ -206,6 +206,8 @@ As noted above, the configuration of your schema and GraphQL documents is done v
 * `--watch`: watches the include globbing patterns for changes and re-processes files (default = `false`)
 * `--cwd`: run tool for `.graphqlconfig` located in this directory (default = `process.cwd()`)
 * `--add-typename`: adds a `__typename` field to every object type (default = `true`)
+* `--export-format`: species the shape of values exported from `.graphql` files (default = `document`)
+  * Options: `document` (exports a `graphql-typed` `DocumentNode`), `simple` (exports a `graphql-typed` `SimpleDocument`)
 * `--enum-format`: specifies output format for enum types (default = `undefined`)
   * Options: `camel-case`, `pascal-case`, `snake-case`, `screaming-snake-case`
   * `undefined` results in using the unchanged name from the schema (verbatim)

--- a/packages/graphql-typescript-definitions/src/cli.ts
+++ b/packages/graphql-typescript-definitions/src/cli.ts
@@ -3,7 +3,7 @@
 import * as chalk from 'chalk';
 import yargs from 'yargs';
 
-import {EnumFormat} from './types';
+import {EnumFormat, ExportFormat} from './types';
 
 import {Builder, SchemaBuild, DocumentBuild} from '.';
 
@@ -33,6 +33,11 @@ const argv = yargs
     default: true,
     type: 'boolean',
     describe: 'Add a __typename field to every object type',
+  })
+  .option('export-format', {
+    required: false,
+    describe: 'The format to use for values exported from GraphQL documents',
+    choices: [ExportFormat.Document, ExportFormat.Simple],
   })
   .option('enum-format', {
     required: false,

--- a/packages/graphql-typescript-definitions/src/index.ts
+++ b/packages/graphql-typescript-definitions/src/index.ts
@@ -39,9 +39,9 @@ import {
   PrintDocumentOptions,
   PrintSchemaOptions,
 } from './print';
-import {EnumFormat} from './types';
+import {EnumFormat, ExportFormat} from './types';
 
-export {EnumFormat};
+export {EnumFormat, ExportFormat};
 
 export interface Options extends PrintDocumentOptions, PrintSchemaOptions {
   addTypename: boolean;

--- a/packages/graphql-typescript-definitions/src/print/document/context.ts
+++ b/packages/graphql-typescript-definitions/src/print/document/context.ts
@@ -4,11 +4,12 @@ import * as t from '@babel/types';
 import {upperCaseFirst} from 'upper-case-first';
 import {AST, Fragment, isOperation, Operation} from 'graphql-tool-utilities';
 
-import {EnumFormat} from '../../types';
+import {EnumFormat, ExportFormat} from '../../types';
 
 export interface Options {
   schemaTypesPath: string;
   enumFormat?: EnumFormat;
+  exportFormat?: ExportFormat;
   addTypename?: boolean;
 }
 

--- a/packages/graphql-typescript-definitions/src/print/document/index.ts
+++ b/packages/graphql-typescript-definitions/src/print/document/index.ts
@@ -8,6 +8,8 @@ import {
   OperationType,
 } from 'graphql-tool-utilities';
 
+import {ExportFormat} from '../../types';
+
 import {Options, FileContext, OperationContext} from './context';
 import {ObjectStack} from './utilities';
 import {tsInterfaceBodyForObjectField, variablesInterface} from './language';
@@ -115,21 +117,19 @@ export function printDocument(
   const {schemaImports} = file;
   const {namespace} = context;
   const {namespace: partialNamespace} = partialContext;
+  const {exportFormat = ExportFormat.Document} = options;
+  const documentType =
+    exportFormat === ExportFormat.Document ? 'DocumentNode' : 'SimpleDocument';
 
   const documentNodeImport = t.importDeclaration(
-    [
-      t.importSpecifier(
-        t.identifier('DocumentNode'),
-        t.identifier('DocumentNode'),
-      ),
-    ],
+    [t.importSpecifier(t.identifier(documentType), t.identifier(documentType))],
     t.stringLiteral('graphql-typed'),
   );
 
   const documentNodeDeclaratorIdentifier = t.identifier('document');
   documentNodeDeclaratorIdentifier.typeAnnotation = t.tsTypeAnnotation(
     t.tsTypeReference(
-      t.identifier('DocumentNode'),
+      t.identifier(documentType),
       t.tsTypeParameterInstantiation([
         t.tsTypeReference(t.identifier(context.typeName)),
         variables || t.tsNeverKeyword(),

--- a/packages/graphql-typescript-definitions/src/types.ts
+++ b/packages/graphql-typescript-definitions/src/types.ts
@@ -4,3 +4,8 @@ export enum EnumFormat {
   PascalCase = 'pascal-case',
   ScreamingSnakeCase = 'screaming-snake-case',
 }
+
+export enum ExportFormat {
+  Document = 'document',
+  Simple = 'simple',
+}

--- a/packages/graphql-typescript-definitions/test/document.test.ts
+++ b/packages/graphql-typescript-definitions/test/document.test.ts
@@ -4,6 +4,7 @@ import {buildSchema, parse, GraphQLSchema, Source, concatAST} from 'graphql';
 import {stripIndent} from 'common-tags';
 import {compile} from 'graphql-tool-utilities';
 
+import {ExportFormat} from '../src/types';
 import {printDocument, Options} from '../src/print/document';
 
 describe('printDocument()', () => {
@@ -1766,6 +1767,39 @@ describe('printDocument()', () => {
 
       expect(print('query Details { name }', schema)).toContain(stripIndent`
         declare const document: DocumentNode<DetailsQueryData, never, DetailsQueryPartialData>;
+        export default document;
+      `);
+    });
+  });
+
+  describe('simple', () => {
+    it('imports a SimpleDocument from graphql-typed', () => {
+      const schema = buildSchema(`
+        type Query {
+          name: String!
+        }
+      `);
+
+      expect(
+        print('query Details { name }', schema, {
+          printOptions: {exportFormat: ExportFormat.Simple},
+        }),
+      ).toContain('import { SimpleDocument } from "graphql-typed";');
+    });
+
+    it('exports a SimpleDocument as the default export with the operation data type annotation', () => {
+      const schema = buildSchema(`
+        type Query {
+          name: String!
+        }
+      `);
+
+      expect(
+        print('query Details { name }', schema, {
+          printOptions: {exportFormat: ExportFormat.Simple},
+        }),
+      ).toContain(stripIndent`
+        declare const document: SimpleDocument<DetailsQueryData, never, DetailsQueryPartialData>;
         export default document;
       `);
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -651,7 +651,7 @@
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
-"@types/common-tags@1.8.0", "@types/common-tags@^1.4.0":
+"@types/common-tags@^1.4.0", "@types/common-tags@^1.8.0":
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@types/common-tags/-/common-tags-1.8.0.tgz#79d55e748d730b997be5b7fce4b74488d8b26a6b"
   integrity sha512-htRqZr5qn8EzMelhX/Xmx142z218lLyGaeZ3YR8jlze4TATRU9huKKvuBmAJEW4LCC4pnY1N6JAm6p85fMHjhg==
@@ -720,6 +720,14 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.4.tgz#38fd73ddfd9b55abb1e1b2ed578cb55bd7b7d339"
   integrity sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==
 
+"@types/loader-utils@^1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@types/loader-utils/-/loader-utils-1.1.3.tgz#82b9163f2ead596c68a8c03e450fbd6e089df401"
+  integrity sha512-euKGFr2oCB3ASBwG39CYJMR3N9T0nanVqXdiH7Zu/Nqddt6SmFRxytq/i2w9LQYNQekEtGBz+pE3qG6fQTNvRg==
+  dependencies:
+    "@types/node" "*"
+    "@types/webpack" "*"
+
 "@types/minimatch@*":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
@@ -733,12 +741,7 @@
     "@types/node" "*"
     form-data "^3.0.0"
 
-"@types/node@*":
-  version "13.11.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.11.1.tgz#49a2a83df9d26daacead30d0ccc8762b128d53c7"
-  integrity sha512-eWQGP3qtxwL8FGneRrC5DwrJLGN4/dH1clNTuLfN81HCrxVtxRjygDTUoZJ5ASlDEeo0ppYFQjQIlXhtXpOn6g==
-
-"@types/node@^10.0.4":
+"@types/node@*", "@types/node@^10.0.4":
   version "10.17.19"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.19.tgz#1d31ddd5503dba2af7a901aafef3392e4955620e"
   integrity sha512-46/xThm3zvvc9t9/7M3AaLEqtOpqlYYYcCZbpYVAQHG20+oMZBkae/VMrn4BTi6AJ8cpack0mEXhGiKmDNbLrQ==
@@ -779,10 +782,10 @@
     "@types/source-list-map" "*"
     source-map "^0.6.1"
 
-"@types/webpack@^4.41.11":
-  version "4.41.11"
-  resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.41.11.tgz#7b7f725397d3b630bede05415d34e9ff30d9771f"
-  integrity sha512-PtEZISfBMWL05qOpZN19hztZPt0rPuGQh5sbBP3bB4RrJgzdb0SScn47hdcMaoN1IgaU7NZWeDO6reFcKTK2iQ==
+"@types/webpack@*", "@types/webpack@^4.41.11":
+  version "4.41.12"
+  resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.41.12.tgz#0386ee2a2814368e2f2397abb036c0bf173ff6c3"
+  integrity sha512-BpCtM4NnBen6W+KEhrL9jKuZCXVtiH6+0b6cxdvNt2EwU949Al334PjQSl2BeAyvAX9mgoNNG21wvjP3xZJJ5w==
   dependencies:
     "@types/anymatch" "*"
     "@types/node" "*"
@@ -1391,6 +1394,11 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+big.js@^5.2.2:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
+  integrity sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
+
 binary-extensions@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.0.0.tgz#23c0df14f6a88077f5f986c0d167ec03c3d5537c"
@@ -1780,7 +1788,7 @@ commander@^2.11.0, commander@~2.20.3:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
-common-tags@1.8.0, common-tags@^1.5.1, common-tags@^1.7.2, common-tags@^1.8.0:
+common-tags@^1.5.1, common-tags@^1.7.2, common-tags@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.8.0.tgz#8e3153e542d4a39e9b10554434afaaf98956a937"
   integrity sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==
@@ -2337,6 +2345,11 @@ emoji-regex@^8.0.0:
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
 
+emojis-list@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-3.0.0.tgz#5570662046ad29e2e916e71aae260abdff4f6a78"
+  integrity sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==
+
 end-of-stream@^1.1.0:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
@@ -2409,18 +2422,10 @@ eslint-import-resolver-node@^0.3.2:
     debug "^2.6.9"
     resolve "^1.13.1"
 
-eslint-module-utils@2.5.0:
+eslint-module-utils@2.5.0, eslint-module-utils@^2.4.1:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.5.0.tgz#cdf0b40d623032274ccd2abd7e64c4e524d6e19c"
   integrity sha512-kCo8pZaNz2dsAW7nCUjuVoI11EBXXpIzfNxmaoLhXoRDOnqXLC4iSGVRdZPhOitfbdEfMEfKOiENaK6wDPZEGw==
-  dependencies:
-    debug "^2.6.9"
-    pkg-dir "^2.0.0"
-
-eslint-module-utils@^2.4.1:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.6.0.tgz#579ebd094f56af7797d19c9866c9c9486629bfa6"
-  integrity sha512-6j9xxegbqe8/kZY8cYpcp0xhbK0EgJlg3g9mib3/miLaExuuwc3n5UEfSnU6hWMbT0FAYVvDbL9RrRgpUeQIvA==
   dependencies:
     debug "^2.6.9"
     pkg-dir "^2.0.0"
@@ -2830,15 +2835,10 @@ extglob@^2.0.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-extsprintf@1.3.0:
+extsprintf@1.3.0, extsprintf@^1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
   integrity sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=
-
-extsprintf@^1.2.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
-  integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
 faker@^4.1.0:
   version "4.1.0"
@@ -4509,6 +4509,15 @@ load-json-file@^4.0.0:
     pify "^3.0.0"
     strip-bom "^3.0.0"
 
+loader-utils@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.0.tgz#e4cace5b816d425a166b5f097e10cd12b36064b0"
+  integrity sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==
+  dependencies:
+    big.js "^5.2.2"
+    emojis-list "^3.0.0"
+    json5 "^2.1.2"
+
 locate-path@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
@@ -5796,17 +5805,10 @@ ret@~0.1.10:
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
-rimraf@2.6.3:
+rimraf@2.6.3, rimraf@^2.6.1:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
   integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
-  dependencies:
-    glob "^7.1.3"
-
-rimraf@^2.6.1:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
-  integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
   dependencies:
     glob "^7.1.3"
 
@@ -5848,12 +5850,7 @@ rxjs@^6.5.3:
   dependencies:
     tslib "^1.9.0"
 
-safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@^5.1.2:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.0.tgz#b74daec49b1148f88c64b68d49b1e815c1f2f519"
-  integrity sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==
-
-safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
@@ -6796,15 +6793,10 @@ vscode-languageserver@^5.1.0:
     vscode-languageserver-protocol "3.14.1"
     vscode-uri "^1.0.6"
 
-vscode-uri@1.0.6:
+vscode-uri@1.0.6, vscode-uri@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-1.0.6.tgz#6b8f141b0bbc44ad7b07e94f82f168ac7608ad4d"
   integrity sha512-sLI2L0uGov3wKVb9EB+vIQBl9tVP90nqRvxSoJ35vI3NjxE8jfsE5DSOhWgSunHSZmKS4OCi2jrtfxK7uyp2ww==
-
-vscode-uri@^1.0.6:
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-1.0.8.tgz#9769aaececae4026fb6e22359cb38946580ded59"
-  integrity sha512-obtSWTlbJ+a+TFRYGaUumtVwb+InIUVI0Lu0VBUAPmj2cU5JutEXg3xUE0c2J5Tcy7h2DEKVJBFi+Y9ZSFzzPQ==
 
 w3c-hr-time@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
This PR introduces a new format that a GraphQL document can be exported in. This format, which I've called `simple` (open to other names; also considered `raw`/ `no-ast`), does not contain the full AST representation of the query (so, no longer a `DocumentNode`). Instead, it has the minimal amount of information needed by a GraphQL client that does a query-based cache: `id` (a hash of the minified document source; useful as a cache key), `source` (the minified document source; need to send as part of network requests), and `name` (the first operation name in the source; need to send as part of network requests). This representation is significantly smaller than the full AST.

While I was here, I also changed the webpack output of a `.graphql` file to be the result of `JSON.parse`ing a string, rather than embedding the object structure in the JavaScript file directly, as this can be [significantly faster for large objects](https://v8.dev/blog/cost-of-javascript-2019#json).