### PR TITLE
Fix chalk import to work with esModuleInterop

### DIFF
--- a/packages/graphql-typescript-definitions/src/cli.ts
+++ b/packages/graphql-typescript-definitions/src/cli.ts
@@ -1,6 +1,6 @@
 /* eslint no-console: off */
 
-import * as chalk from 'chalk';
+import chalk from 'chalk';
 import yargs from 'yargs';
 
 import {EnumFormat, ExportFormat} from './types';

--- a/packages/graphql-typescript-definitions/src/index.ts
+++ b/packages/graphql-typescript-definitions/src/index.ts
@@ -10,7 +10,7 @@ import {
   Source,
   concatAST,
 } from 'graphql';
-import * as chalk from 'chalk';
+import chalk from 'chalk';
 import {mkdirp, readFile, writeFile} from 'fs-extra';
 import {FSWatcher, watch} from 'chokidar';
 import {

--- a/packages/graphql-validate-fixtures/src/cli.ts
+++ b/packages/graphql-validate-fixtures/src/cli.ts
@@ -4,7 +4,7 @@ import {relative, basename} from 'path';
 
 import yargs from 'yargs';
 import * as glob from 'glob';
-import * as chalk from 'chalk';
+import chalk from 'chalk';
 
 import {evaluateFixtures} from '.';
 


### PR DESCRIPTION
I introduced a change that incorrectly imported chalk. See https://github.com/chalk/chalk/issues/399
This PR fixes it.

