### PR TITLE
Update generateSchemaTypes to group import and export statements

### DIFF
--- a/packages/graphql-typescript-definitions/test/schema.test.ts
+++ b/packages/graphql-typescript-definitions/test/schema.test.ts
@@ -197,6 +197,12 @@ describe('printSchema()', () => {
         SIX
       }
 
+      enum Season {
+        FIRST
+        SECOND
+        THIRD
+      }
+
       scalar Date
 
       input InputOne {
@@ -208,12 +214,15 @@ describe('printSchema()', () => {
       input InputTwo {
         name: String
         episode: Episode!
+        season: Season!
         date: Date
       }
     `);
 
     expect(generateSchemaTypes(schema).get('index.ts')).toContain(stripIndent`
+      import { Season } from "./Season";
       import { Episode } from "./Episode";
+      export { Season };
       export { Episode };
       export type Date = string;
       export interface InputOne {
@@ -224,6 +233,7 @@ describe('printSchema()', () => {
       export interface InputTwo {
         name?: string | null;
         episode: Episode;
+        season: Season;
         date?: Date | null;
       }
     `);


### PR DESCRIPTION
Fixes https://github.com/Shopify/graphql-tools-web/issues/117

As @patsissons mentioned:  "When generating the schema types module, the generated `index.ts` will contain interleaved `import` and `export` statements rather than a properly formed module that places all imports first and all exports second"

This fix updates `generateSchemaTypes` to group import and export statements and concat them at the end so that the generated file is in compliance with `import/first` eslint rule.

**Example**

Before:
```ts
import { Season } from "./Season";
export { Season };
import { Episode } from "./Episode";
export { Episode };
export type Date = string;

export interface InputOne {
  dates: (Date | null)[];
  episodes: Episode[];
  season: Season;
  inputs?: (InputTwo | null)[] | null;
}
```

After:
```ts
import { Season } from "./Season";
import { Episode } from "./Episode";
export { Season };
export { Episode };
export type Date = string;

export interface InputOne {
  dates: (Date | null)[];
  episodes: Episode[];
  season: Season;
  inputs?: (InputTwo | null)[] | null;
}
```
