### PR TITLE
Bump version

### DIFF
--- a/packages/graphql-typescript-definitions/package.json
+++ b/packages/graphql-typescript-definitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-typescript-definitions",
-  "version": "0.20.2",
+  "version": "0.20.4",
   "main": "lib/index.js",
   "types": "lib",
   "description": "Generate TypeScript definition files from .graphql documents",


### PR DESCRIPTION
Part of fix for https://github.com/Shopify/graphql-tools-web/issues/117

Bumping version for change added in:  https://github.com/Shopify/graphql-tools-web/pull/118

New version: `0.20.4`