### PR TITLE
[graphql-mini-transforms] Support importing documents without operations (only fragments)

### DIFF
--- a/packages/graphql-mini-transforms/src/document.ts
+++ b/packages/graphql-mini-transforms/src/document.ts
@@ -16,7 +16,7 @@ const DEFAULT_NAME = 'Operation';
 
 export function cleanDocument(
   document: DocumentNode,
-  {removeUnused = true} = {},
+  {removeUnused = shouldRemoveUnusedDefinitions(document)} = {},
 ) {
   if (removeUnused) {
     removeUnusedDefinitions(document);
@@ -239,4 +239,8 @@ function stripLoc(value: unknown) {
       stripLoc((value as any)[key]);
     }
   }
+}
+
+function shouldRemoveUnusedDefinitions(document: DocumentNode) {
+  return document.definitions.length > 1;
 }

--- a/packages/graphql-mini-transforms/src/document.ts
+++ b/packages/graphql-mini-transforms/src/document.ts
@@ -16,7 +16,7 @@ const DEFAULT_NAME = 'Operation';
 
 export function cleanDocument(
   document: DocumentNode,
-  {removeUnused = shouldRemoveUnusedDefinitions(document)} = {},
+  {removeUnused = true} = {},
 ) {
   if (removeUnused) {
     removeUnusedDefinitions(document);
@@ -239,8 +239,4 @@ function stripLoc(value: unknown) {
       stripLoc((value as any)[key]);
     }
   }
-}
-
-function shouldRemoveUnusedDefinitions(document: DocumentNode) {
-  return document.definitions.length > 1;
 }

--- a/packages/graphql-mini-transforms/src/document.ts
+++ b/packages/graphql-mini-transforms/src/document.ts
@@ -84,9 +84,32 @@ function removeUnusedDefinitions(document: DocumentNode) {
     }
   };
 
-  for (const definition of document.definitions) {
-    if (definition.kind !== 'FragmentDefinition') {
-      markAsUsed(definition);
+  if (
+    document.definitions.some(
+      (definition) => definition.kind !== 'FragmentDefinition',
+    )
+  ) {
+    // There is at least one operation in the document.
+    for (const definition of document.definitions) {
+      if (definition.kind !== 'FragmentDefinition') {
+        markAsUsed(definition);
+      }
+    }
+  } else {
+    // No operations are defined.
+    const numDefinitions = document.definitions.length;
+    for (const definition of document.definitions) {
+      // If any fragment imports all other definitions, mark that one as used.
+      if ((dependencies.get(definition) || []).length === numDefinitions - 1) {
+        markAsUsed(definition);
+        break;
+      }
+    }
+
+    if (usedDefinitions.size === 0) {
+      throw new Error(
+        '@shopify/graphql-loader could not identify any used definitions in this document',
+      );
     }
   }
 

--- a/packages/graphql-mini-transforms/tests/webpack.test.ts
+++ b/packages/graphql-mini-transforms/tests/webpack.test.ts
@@ -210,6 +210,34 @@ describe('graphql-mini-transforms/webpack', () => {
 
       expect(body).not.toContain('fragment FooFragment on Shop');
     });
+
+    it('includes imported sources if a fragment is the only export', async () => {
+      const context = '/app/';
+      const loader = createLoaderContext({
+        context,
+        readFile: () => `fragment FooFragment on Shop { id }`,
+      });
+
+      const {
+        loc: {
+          source: {body},
+        },
+      } = await extractDocumentExport(
+        stripIndent`
+          #import './FooFragment.graphql';
+
+          fragment ShopFragment on Query {
+            shop {
+              ...FooFragment
+            }
+          }
+        `,
+        loader,
+      );
+
+      expect(body).toContain('fragment FooFragment on Shop');
+      expect(body).toContain('fragment ShopFragment on Query');
+    });
   });
 });
 

--- a/packages/graphql-mini-transforms/tests/webpack.test.ts
+++ b/packages/graphql-mini-transforms/tests/webpack.test.ts
@@ -81,6 +81,17 @@ describe('graphql-mini-transforms/webpack', () => {
     );
   });
 
+  it('provides a useful error when a document is ambiguous', async () => {
+    const fragment = stripIndent`
+      fragment Foo on Shop{__typename}
+      fragment Bar on Shop{__typename}
+    `;
+
+    await expect(extractDocumentExport(fragment)).rejects.toThrow(
+      '@shopify/graphql-loader could not identify any used definitions in this document',
+    );
+  });
+
   describe('import', () => {
     it('adds the resolved import as a dependency', async () => {
       const context = '/app/';

--- a/packages/graphql-mini-transforms/tests/webpack.test.ts
+++ b/packages/graphql-mini-transforms/tests/webpack.test.ts
@@ -72,6 +72,15 @@ describe('graphql-mini-transforms/webpack', () => {
     );
   });
 
+  it('outputs a fragment when it is the only definition in the document', async () => {
+    const fragment = `fragment MyShop on Shop{__typename}`;
+
+    expect(await extractDocumentExport(fragment)).toHaveProperty(
+      'loc.source.body',
+      fragment,
+    );
+  });
+
   describe('import', () => {
     it('adds the resolved import as a dependency', async () => {
       const context = '/app/';


### PR DESCRIPTION
Fixes #92 

This approach tries to support documents without operations, as long as it's not ambiguous which fragment should be treated as the default export.

e.g.

This is supported (and not order dependent):

```graphql
fragment FooFragment on Query {
  shop {
    ...BarFragment
  }
}

fragment BarFragment on Shop {
  __typename
}
```

This is not supported:

```graphql
fragment FooFragment on Shop {
  __typename
}

fragment BarFragment on Shop {
  __typename
}
```

I also added a slightly more useful error for debugging unsupported documents.