### PR TITLE
Always output a valid es module file

### DIFF
--- a/packages/graphql-typescript-definitions/CHANGELOG.md
+++ b/packages/graphql-typescript-definitions/CHANGELOG.md
@@ -5,6 +5,8 @@ and from `v0.14.0`, this project adheres to [Semantic Versioning](http://semver.
 
 ## [Unreleased]
 
+- Ensure we add an `export {}` to otherwise blank files to make it clear that they are in the es modules format [[#131](https://github.com/Shopify/graphql-tools-web/pull/131)]
+
 ## [0.21.0] - 2020-06-15
 
 - Allow custom scalars that alias built-in types [[#90](https://github.com/Shopify/graphql-tools-web/pull/90)] (thanks [ryanw](https://github.com/ryanw)!)

--- a/packages/graphql-typescript-definitions/src/print/schema/index.ts
+++ b/packages/graphql-typescript-definitions/src/print/schema/index.ts
@@ -104,6 +104,15 @@ export function generateSchemaTypes(
     }
   }
 
+  // A blank file is ambiguous - its not clear if it is a script or a module.
+  // If the file would be blank then give it an empty `export {}` to make in
+  // unambiguously an es module file.
+  // This ensures the generated files passes TypeScript type checking in
+  // "isolatedModules" mode.
+  if (exportFileBody.length === 0) {
+    exportFileBody.push(t.exportNamedDeclaration(null, []));
+  }
+
   return definitions.set(
     'index.ts',
     generate(t.file(t.program(importFileBody.concat(exportFileBody)), [], []))

--- a/packages/graphql-typescript-definitions/test/schema.test.ts
+++ b/packages/graphql-typescript-definitions/test/schema.test.ts
@@ -94,6 +94,13 @@ describe('printSchema()', () => {
     });
   });
 
+  it('prints a unambiguous es module file if nothing would otherwise be exported', () => {
+    const schema = buildSchema('type Query {getValue: String}');
+    expect(generateSchemaTypes(schema).get('index.ts')).toStrictEqual(
+      'export {};',
+    );
+  });
+
   it('prints a custom scalar in the index file', () => {
     const schema = buildSchema('scalar Date');
     expect(generateSchemaTypes(schema).get('index.ts')).toContain(


### PR DESCRIPTION
In the unlikely event that a schema is borderline empty and wouldn't
produce any types we previously outputted a blank file. Which causes
type checking with isolatedModules enabled to fail because a blank file
is ambigiuous - it could be a script or a module. This change ensures
that if a file would otherwise be blank we output a `export {}` to make
it clear that the file should be treated as an es modules file.